### PR TITLE
docs(install): point install paths at skills/sprint/ subdirectory (Refs #15)

### DIFF
--- a/skills/sprint/docs/install/claude-code.md
+++ b/skills/sprint/docs/install/claude-code.md
@@ -15,13 +15,23 @@ In Claude Code:
 
 ## Install (manual) — git clone
 
-Global:
+The skill source lives in `skills/sprint/` inside the bundle repo. Clone the repo to a workspace path, then symlink (or copy) the skill into Claude Code's skills directory.
+
+Global, with a symlink (recommended — keeps `git pull` in one place):
 
 ```bash
-git clone https://github.com/leverj/agent-skills ~/.claude/skills/sprint
+git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
+ln -s ~/sprint-workflow/skills/sprint ~/.claude/skills/sprint
 ```
 
-Per-project: clone into `.claude/skills/sprint` instead.
+If symlinks aren't available, copy and re-copy on update:
+
+```bash
+git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
+cp -R ~/sprint-workflow/skills/sprint ~/.claude/skills/sprint
+```
+
+Per-project: replace `~/.claude/skills/sprint` with `.claude/skills/sprint` inside the project root.
 
 Optionally append `claude-md-snippet.md` to your project's `CLAUDE.md`.
 
@@ -44,8 +54,26 @@ Recommended (from inside any project that uses the skill):
 
 See [Upgrade Command](../../SKILL.md#upgrade-command) for branch switching (`/sprint upgrade <branch>`, `/sprint upgrade reset`, `/sprint upgrade check`).
 
-Manual fallback:
+Manual fallback (symlink install):
 
 ```bash
-cd ~/.claude/skills/sprint && git pull
+cd ~/sprint-workflow && git pull
+```
+
+If you copied instead of symlinked, re-copy after pulling:
+
+```bash
+cd ~/sprint-workflow && git pull
+rm -rf ~/.claude/skills/sprint
+cp -R ~/sprint-workflow/skills/sprint ~/.claude/skills/sprint
+```
+
+## Migration (existing manual installs)
+
+If you previously cloned the bundle directly into `~/.claude/skills/sprint` (pre-restructure), that checkout no longer has `SKILL.md` at its root after `git pull` — the skill source moved into `skills/sprint/`. Either switch to the marketplace install above, or re-do the manual install:
+
+```bash
+rm -rf ~/.claude/skills/sprint
+git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
+ln -s ~/sprint-workflow/skills/sprint ~/.claude/skills/sprint
 ```

--- a/skills/sprint/docs/install/codex.md
+++ b/skills/sprint/docs/install/codex.md
@@ -7,7 +7,7 @@ Codex auto-discovers `AGENTS.md` in the project root. This repo ships `AGENTS.md
 ```bash
 git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
 cd /path/to/your/project
-ln -s ~/sprint-workflow/AGENTS.md AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```
 
 If symlinks aren't supported, `cp` instead and re-copy on update.
@@ -35,4 +35,13 @@ Manual fallback:
 
 ```bash
 cd ~/sprint-workflow && git pull
+```
+
+## Migration (existing manual installs)
+
+If you symlinked `AGENTS.md` to `~/sprint-workflow/AGENTS.md` before the bundle restructure, the symlink breaks on next `git pull` (the skill source moved into `skills/sprint/`). Recreate it:
+
+```bash
+rm AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```

--- a/skills/sprint/docs/install/copilot-cli.md
+++ b/skills/sprint/docs/install/copilot-cli.md
@@ -7,10 +7,10 @@ Copilot CLI treats `AGENTS.md` in the repo root as primary instructions (and add
 ```bash
 git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
 cd /path/to/your/project
-ln -s ~/sprint-workflow/AGENTS.md AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```
 
-(If symlinks aren't available, copy: `cp ~/sprint-workflow/AGENTS.md AGENTS.md` and re-copy on update.)
+(If symlinks aren't available, copy: `cp ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md` and re-copy on update.)
 
 ## Invocation
 
@@ -35,4 +35,13 @@ Manual fallback:
 
 ```bash
 cd ~/sprint-workflow && git pull
+```
+
+## Migration (existing manual installs)
+
+If you symlinked or copied `AGENTS.md` from `~/sprint-workflow/AGENTS.md` before the bundle restructure, that target is gone on next `git pull` (the skill source moved into `skills/sprint/`). Recreate it:
+
+```bash
+rm AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```

--- a/skills/sprint/docs/install/cursor.md
+++ b/skills/sprint/docs/install/cursor.md
@@ -7,10 +7,10 @@ Cursor auto-discovers `AGENTS.md` in the project root (and nested dirs). It also
 ```bash
 git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
 cd /path/to/your/project
-ln -s ~/sprint-workflow/AGENTS.md AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```
 
-Alternative: `mkdir -p .cursor/rules && ln -s ~/sprint-workflow/SKILL.md .cursor/rules/sprint.mdc`.
+Alternative: `mkdir -p .cursor/rules && ln -s ~/sprint-workflow/skills/sprint/SKILL.md .cursor/rules/sprint.mdc`.
 
 ## Invocation
 
@@ -36,4 +36,14 @@ Manual fallback:
 
 ```bash
 cd ~/sprint-workflow && git pull
+```
+
+## Migration (existing manual installs)
+
+If you symlinked `AGENTS.md` to `~/sprint-workflow/AGENTS.md` (or `.cursor/rules/sprint.mdc` to `~/sprint-workflow/SKILL.md`) before the bundle restructure, those symlinks break on next `git pull` (the skill source moved into `skills/sprint/`). Recreate them:
+
+```bash
+rm AGENTS.md && ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
+# or, for the rules variant:
+rm .cursor/rules/sprint.mdc && ln -s ~/sprint-workflow/skills/sprint/SKILL.md .cursor/rules/sprint.mdc
 ```

--- a/skills/sprint/docs/install/gemini-cli.md
+++ b/skills/sprint/docs/install/gemini-cli.md
@@ -11,7 +11,7 @@ git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
 In each project, create `GEMINI.md` containing:
 
 ```
-@~/sprint-workflow/SKILL.md
+@~/sprint-workflow/skills/sprint/SKILL.md
 ```
 
 ## Invocation
@@ -37,4 +37,12 @@ Manual fallback:
 
 ```bash
 cd ~/sprint-workflow && git pull
+```
+
+## Migration (existing manual installs)
+
+If your `GEMINI.md` imports `@~/sprint-workflow/SKILL.md` from a pre-restructure install, the import breaks on next `git pull` (the skill source moved into `skills/sprint/`). Update it to:
+
+```
+@~/sprint-workflow/skills/sprint/SKILL.md
 ```

--- a/skills/sprint/docs/install/opencode.md
+++ b/skills/sprint/docs/install/opencode.md
@@ -7,10 +7,10 @@ OpenCode auto-discovers `AGENTS.md` in the project root.
 ```bash
 git clone https://github.com/leverj/claude-sprint ~/sprint-workflow
 cd /path/to/your/project
-ln -s ~/sprint-workflow/AGENTS.md AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```
 
-(If symlinks aren't available, copy: `cp ~/sprint-workflow/AGENTS.md AGENTS.md` and re-copy on update.)
+(If symlinks aren't available, copy: `cp ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md` and re-copy on update.)
 
 ## Invocation
 
@@ -35,4 +35,13 @@ Manual fallback:
 
 ```bash
 cd ~/sprint-workflow && git pull
+```
+
+## Migration (existing manual installs)
+
+If you symlinked or copied `AGENTS.md` from `~/sprint-workflow/AGENTS.md` before the bundle restructure, that target is gone on next `git pull` (the skill source moved into `skills/sprint/`). Recreate it:
+
+```bash
+rm AGENTS.md
+ln -s ~/sprint-workflow/skills/sprint/AGENTS.md AGENTS.md
 ```


### PR DESCRIPTION
Closes #15

## Summary
- Update 5 non-Claude install docs (codex, gemini-cli, cursor, opencode, copilot-cli) to reference `skills/sprint/AGENTS.md` (or `skills/sprint/SKILL.md`).
- Rewrite `claude-code.md` manual install: clone to `~/sprint-workflow`, then symlink or copy `skills/sprint/` into `~/.claude/skills/sprint/`. Marketplace path stays as the recommended option.
- Add a "Migration (existing manual installs)" section to all 6 docs explaining how to recover after `git pull`.

## Acceptance Criteria Verified
- WHEN a Codex CLI user reads `docs/install/codex.md`, the symlink command targets `~/sprint-workflow/skills/sprint/AGENTS.md` — verified.
- WHEN a Cursor / OpenCode / Copilot CLI user reads their install doc, the same path adjustment is in place — verified.
- WHEN a Gemini CLI user reads `docs/install/gemini-cli.md`, the `@`-import line is `@~/sprint-workflow/skills/sprint/SKILL.md` — verified.
- WHEN a Claude Code user reads `docs/install/claude-code.md`, both marketplace (recommended) and manual (clone + symlink/copy `skills/sprint/`) paths are documented — verified.
- WHEN a user reads any install doc's "Update" section, the `cd ~/sprint-workflow && git pull` form continues to work; only the symlink target changed — verified.

## Test Plan
- [ ] Render each `docs/install/*.md` and confirm symlink/import lines reference `skills/sprint/`.
- [ ] Walk through the manual claude-code install (clone + symlink) on a clean machine.
- [ ] Walk through a migration: existing `~/sprint-workflow/AGENTS.md` symlink, run `git pull`, follow the migration block, verify the skill loads.

## Dependency Safety
No dependency changes.