### PR TITLE
feat(security-scan): add skill driving leverj/security-scan (digest-pinned)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent skills bundle for AI coding tools",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,17 +6,18 @@
   },
   "metadata": {
     "description": "Agent skills bundle for AI coding tools",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {
       "name": "leverj",
-      "description": "Leverj agent skills bundle. Includes: sprint (scrum/kanban workflow on GitHub Projects v2 — issues are requirements, Project fields are state, ADRs in .dev/decisions/); triage (end-to-end triage & fix loop over an epic's sub-issues or a GitHub Projects v2 board — auto-closes dup/wontfix, bundles trivial dep bumps into PRs).",
+      "description": "Leverj agent skills bundle. Includes: sprint (scrum/kanban workflow on GitHub Projects v2 — issues are requirements, Project fields are state, ADRs in .dev/decisions/); triage (end-to-end triage & fix loop over an epic's sub-issues or a GitHub Projects v2 board — auto-closes dup/wontfix, bundles trivial dep bumps into PRs); security-scan (drives the leverj/security-scan Docker image to scan a repo for vulnerabilities, secrets, and SAST issues; files findings into a GitHub Projects v2 board with a user-confirmed image-upgrade + config-migration flow).",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/sprint",
-        "./skills/triage"
+        "./skills/triage",
+        "./skills/security-scan"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Each skill lives under `skills/<name>/` and ships its own `SKILL.md`, install do
 | --- | --- | --- |
 | **sprint** | Scrum/kanban-aware development workflow on top of GitHub Projects v2. Issues are requirements; Project fields are state; ADRs in `.dev/decisions/`. | [SKILL.md](skills/sprint/SKILL.md) · [README](skills/sprint/README.md) |
 | **triage** | End-to-end triage & fix loop over a long-lived backlog — an epic's open sub-issues **or** a GitHub Projects v2 board (set in `.dev/triage.json`, overridable per call with `--epic`/`--project`). Auto-closes duplicates and won't-fixes, bundles trivial dep bumps into one PR per ecosystem, ships them. | [SKILL.md](skills/triage/SKILL.md) |
+| **security-scan** | Drives the published `leverj/security-scan` Docker image to scan a repo for CVEs, secrets, SAST patterns, IaC misconfigs, and (optionally) LLM-driven SAST with cross-validation. Files findings into a GitHub Projects v2 board. Each run checks Docker Hub for a newer image and offers a user-confirmed upgrade + config-migration flow, driven by the image's baked-in `SECURITY-SCAN-MANIFEST.yaml`. | [SKILL.md](skills/security-scan/SKILL.md) |
 
 ## Install
 

--- a/skills/security-scan/SKILL.md
+++ b/skills/security-scan/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: security-scan
+description: >
+  Run the security-scan scanner against a repo via the published
+  `leverj/security-scan` Docker image. Detects the repo's tech stack, runs
+  OSV-Scanner, Gitleaks, Semgrep, Trivy, Trufflehog (and optionally LLM-driven
+  Codex + Gemma SAST with bidirectional cross-validation), and files each
+  finding into a GitHub Projects v2 board. On every run, checks Docker Hub for
+  a newer image and — on user confirmation — pulls it and applies any new
+  config-schema migrations declared in the image's SECURITY-SCAN-MANIFEST.yaml.
+  Use when the user says "scan", "/security-scan", "run security-scan",
+  "scan this repo for security issues", "check for secrets / CVEs / SAST
+  issues", or "audit dependencies".
+allowed-tools: Bash(docker *) Bash(curl *) Bash(jq *) Bash(yq *) Bash(gh *) Bash(op *) Bash(ls *) Bash(cat *) Bash(mkdir *) Bash(cp *) Read Write Edit Glob Grep
+argument-hint: "[run|setup|upgrade|check] [--config-dir <path>] [--no-dry-run] [--no-update-check]"
+effort: medium
+---
+
+# security-scan — Security Scanner skill
+
+Drives the `leverj/security-scan` Docker image. The image is stateless; all
+per-deployment state lives in a **config directory** (defaults to
+`~/.security-scan/`) and in a **GitHub Projects v2 board** the user owns.
+Between runs the skill keeps two small files in the user's config dir:
+
+- `config.yaml`                — the live config (the unit of configuration).
+- `.security-scan-state.yaml`  — managed by the skill; tracks pinned image tag.
+
+This skill never writes inside the image. It only:
+
+1. Pulls the image (when needed),
+2. Bind-mounts the user's config dir at `/config:ro`,
+3. Reads the image's `/app/SECURITY-SCAN-MANIFEST.yaml` to learn what version
+   is inside and what config fields it expects,
+4. Drives `docker run` with the right flags.
+
+## Invocation
+
+```
+/leverj:security-scan                       same as `run`
+/leverj:security-scan run [flags]           dry-run the scanner (default)
+/leverj:security-scan run --no-dry-run      file issues into the Projects v2 board
+/leverj:security-scan setup                 first-time interactive config setup
+/leverj:security-scan upgrade               explicitly check for + apply image updates
+/leverj:security-scan check                 verify config + image + auth, exit
+```
+
+Flags accepted on every subcommand:
+
+- `--config-dir <path>` — use a non-default config dir (default `~/.security-scan`).
+- `--no-update-check`   — skip the pre-run Docker Hub check (faster; offline-OK).
+- `--image <ref>`       — override `leverj/security-scan` (e.g., for a fork).
+
+## Phase-by-phase operating procedure
+
+Run these phases in order. Stop on the first hard failure with a clear
+message to the user.
+
+### Phase 0 — Locate config dir
+
+Resolve in priority order:
+1. `--config-dir <path>` flag if passed.
+2. `SECURITY_SCAN_CONFIG_DIR` env var.
+3. `~/.security-scan/`.
+
+If the chosen directory doesn't contain `config.yaml`:
+- For subcommand `setup`: proceed to interactive setup (Phase A below).
+- For everything else: stop and tell the user to run
+  `/leverj:security-scan setup`.
+
+### Phase 1 — Resolve pinned image tag
+
+Read `<config-dir>/.security-scan-state.yaml`. Expected shape:
+
+```yaml
+pinned_tag: "0.2.0"
+pinned_digest: "sha256:abc..."
+image: "leverj/security-scan"
+last_checked: "2026-06-02T12:00:00Z"
+```
+
+If the state file is missing or has no `pinned_tag`, treat as **first run**:
+proceed to Phase 2 to pick the latest tag, then continue.
+
+### Phase 2 — Check for image updates
+
+Skip this phase if `--no-update-check` was passed or if the last check was
+less than 6 hours ago (cheap throttle to avoid hammering Docker Hub on rapid
+re-runs).
+
+1. Query Docker Hub for the most recent tag:
+   ```bash
+   curl -fsSL "https://hub.docker.com/v2/repositories/leverj/security-scan/tags?page_size=10&ordering=last_updated" \
+     | jq -r '.results[].name' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+   ```
+2. Normalize: strip a leading `v` for comparison; both `v0.2.0` and `0.2.0` are
+   accepted. The manifest's `version` is canonical (no `v` prefix).
+3. Compare to the pinned tag:
+   - If equal → no update; record `last_checked` and continue to Phase 3.
+   - If different → fetch the new image's manifest (Phase 2a).
+
+#### Phase 2a — Inspect the candidate image's manifest
+
+Pull the metadata WITHOUT replacing the user's pinned image yet:
+
+```bash
+# Pull just enough to read the manifest. `cat` is the entrypoint override.
+docker pull -q "leverj/security-scan:${CANDIDATE_TAG}"
+docker run --rm --entrypoint cat \
+  "leverj/security-scan:${CANDIDATE_TAG}" /app/SECURITY-SCAN-MANIFEST.yaml \
+  > /tmp/security-scan-manifest-${CANDIDATE_TAG}.yaml
+```
+
+Parse the manifest with `yq` (or fall back to a `python3 -c` one-liner if
+`yq` isn't on PATH). Surface to the user:
+
+- The version delta (e.g., `0.1.0 → 0.2.0`).
+- The `changelog` lines as a bullet list.
+- A summary of `breaking_changes` if any (each is `id + summary + user_action`).
+- A summary of pending config changes:
+  - `new_fields` not already in their `config.yaml` → "the skill will ADD these (with defaults)".
+  - `renamed_fields` where the old name is in their `config.yaml` → "the skill will RENAME these in place".
+  - `removed_fields` present in their `config.yaml` → "the skill will REMOVE these (with confirmation)".
+
+#### Phase 2b — Ask for confirmation
+
+Print a clear yes/no prompt. If `breaking_changes` is non-empty, require an
+explicit `yes` (not just `y`). If no breaking changes, a plain `y` suffices.
+
+If the user declines:
+- Keep the current pinned tag.
+- Record `last_checked` (so the throttle kicks in next time).
+- Continue to Phase 3 with the old image.
+
+If the user accepts:
+- Write the new pinned tag + digest to `.security-scan-state.yaml`.
+- Apply config migrations (Phase 2c).
+
+#### Phase 2c — Apply config migrations
+
+Make a backup first: `cp config.yaml config.yaml.bak-<timestamp>`. Then:
+
+1. **Renames** — for each entry in `config.renamed_fields`, if the `from` key
+   exists in the user's config, rename it to `to`. If the migration note
+   says the rename needs human input (e.g., `parent_issue (int) → project
+   (mapping)`), surface a prompt asking for the required values, then write
+   the new structure.
+2. **New fields** — for each entry in `config.new_fields` whose `path` is NOT
+   already set in the user's config, set it to the documented `default`. For
+   entries with `required: true`, prompt the user (don't silently write
+   `null`).
+3. **Removed fields** — for each entry in `config.removed_fields` present in
+   the user's config, show what's being stripped and confirm before removing.
+
+Show the resulting diff (e.g., `diff -u config.yaml.bak-* config.yaml`) and
+ask the user to confirm one more time before continuing. If they reject,
+restore from the `.bak` file and stop.
+
+### Phase 3 — Verify config + secrets
+
+Run a non-destructive check before invoking the scanner. The goal is to fail
+fast on missing prereqs, not to scan.
+
+For `secrets.source: env`:
+- `GITHUB_TOKEN` must be exported in the current shell.
+- If `slack.enabled: true`, the var named by `slack.webhook_url_env` (or
+  `channel_id_env` + `bot_token_env`) must be exported.
+
+For `secrets.source: 1password`:
+- `op` must be on `PATH` and `op account list` must succeed (signed-in).
+- `<config-dir>/<secrets.env_file>` must exist.
+
+Required config keys (check by reading `<config-dir>/config.yaml`):
+- `repo` (matches `owner/name`)
+- `ref`
+- `project.owner` and `project.number` (the Projects v2 board)
+- `github_token_env`
+
+If any check fails, surface a clear remediation and stop.
+
+### Phase 4 — Run
+
+```bash
+docker run --rm \
+  -v "${CONFIG_DIR}:/config:ro" \
+  -e GITHUB_TOKEN \
+  $([ "${SLACK_FORWARDED}" ] && echo -e SLACK_WEBHOOK_URL) \
+  "leverj/security-scan:${PINNED_TAG}" \
+  $([ -z "${NO_DRY_RUN}" ] && echo --dry-run)
+```
+
+For `secrets.source: 1password`, wrap the above with:
+
+```bash
+op run --env-file="${CONFIG_DIR}/${ENV_FILE}" -- \
+  docker run --rm ... (same as above)
+```
+
+`op` populates this shell's env JIT; `docker run -e GITHUB_TOKEN` (no value!)
+copies it into the container without putting it on argv.
+
+### Phase 5 — Report
+
+After the container exits, surface to the user:
+
+1. The final `summary:` line verbatim from stderr.
+2. Any `scanner X: NOT COMPLETED` lines.
+3. Direct link to the project board:
+   `https://github.com/orgs/<project.owner>/projects/<project.number>`.
+4. The dry-run / real-run mode, explicitly stated.
+5. If `--no-dry-run` was passed, the count of issues actually filed.
+
+DO NOT paste the full stderr log into your reply — it can be hundreds of
+lines. Quote relevant excerpts only.
+
+## Phase A — First-time `setup` (interactive)
+
+Triggered by `/leverj:security-scan setup` or when Phase 0 finds no config.
+
+1. `mkdir -p ~/.security-scan`.
+2. Pull the latest image: `docker pull leverj/security-scan:latest`.
+3. Read the image's manifest with
+   `docker run --rm --entrypoint cat leverj/security-scan:latest /app/SECURITY-SCAN-MANIFEST.yaml`.
+4. Use the manifest's `config.new_fields` (where `required: true`) as the
+   prompt schema. Ask the user for each required value:
+   - `repo` (e.g., `leverj/ezel`)
+   - `ref` (default `main`)
+   - `project.owner` (org or user)
+   - `project.number` (project number from the URL)
+5. Ask which secret path: env (default) or 1password. If 1password, also ask
+   for the env file path.
+6. Write `~/.security-scan/config.yaml` with the required fields filled in
+   and the optional ones at their documented defaults.
+7. If `secrets.source: 1password`, copy the image-baked example to
+   `~/.security-scan/.env.1password.tpl` and tell the user to edit it with
+   their `op://vault/item/...` paths. Get the template contents with:
+   ```bash
+   docker run --rm --entrypoint cat \
+     leverj/security-scan:latest /app/config/.env.1password.tpl.example
+   ```
+8. Tell the user the PAT scopes required (`repo` + `project`) and where to
+   create one.
+9. Run Phase 3 (verify) to confirm everything's wired.
+10. Run a dry-run (Phase 4 with `--dry-run`) and report (Phase 5).
+
+## Hard rules
+
+These are non-negotiable. They protect the user and the source of truth.
+
+- **NEVER pass `--no-dry-run` unless the user explicitly confirmed it in the
+  current turn.** The default is dry-run for a reason — security-scan files
+  real GitHub issues. Surprise filings are a trust violation.
+- **NEVER include secrets in your replies.** `GITHUB_TOKEN`, 1Password env
+  file contents, Slack webhooks must never appear in your messages.
+  security-scan scrubs these from its own logs; you must scrub yours.
+- **NEVER edit `config.yaml` silently.** Every change (new field added,
+  renamed, removed) MUST be shown as a diff and confirmed before writing.
+- **NEVER edit the image.** The skill drives a published image; you don't
+  modify it. Bug fixes / feature requests for security-scan itself belong in
+  `leverj/security-scanner`.
+- **The Projects v2 board is the source of triage truth.** Don't try to dedup
+  findings yourself — that's security-scan's job (deterministic fingerprints
+  in the issue body). Don't close or comment on issues the scanner files;
+  triage is a separate workflow (`/leverj:triage`).
+- **Honor `--no-update-check`.** Skip the Docker Hub probe entirely; don't
+  try to be clever and check anyway "just in case".
+
+## Notes on the `.security-scan-state.yaml` file
+
+The skill owns this file. Users don't edit it by hand. Recognized keys:
+
+```yaml
+pinned_tag:    "0.2.0"                # the docker tag in use
+pinned_digest: "sha256:abc..."        # immutable digest for reproducibility
+image:         "leverj/security-scan" # in case user pointed at a fork
+last_checked:  "2026-06-02T12:00:00Z" # ISO 8601 UTC; controls the 6h throttle
+last_upgrade:  "2026-06-02T11:55:00Z" # records the most recent successful upgrade
+```
+
+Re-creating it from scratch is safe — Phase 1 detects the missing file and
+treats it as a first run.
+
+## When something goes wrong
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `docker: command not found` | Docker not installed | Tell user to install Docker Desktop |
+| `Cannot connect to the Docker daemon` | Docker not running | Tell user to start Docker Desktop |
+| `pull access denied` | Image name typo or private repo | Verify `image` in state.yaml is `leverj/security-scan` |
+| `secrets env file not found` | 1Password path missing | Run `setup` again or copy the example |
+| `op not signed in` | 1Password CLI logged out | `op signin` in the user's shell, then retry |
+| `GitHub API 404: project not found` | Wrong owner/number OR PAT missing `project` scope | Verify project URL + PAT scopes |
+| `scanners completed: 0` and several failures | Network or image corruption | Re-pull the image, re-run |
+| Schema mismatch on manifest read | Older image with no manifest | Pin to a known-good tag in state.yaml; old images don't have the manifest contract |
+
+## Companion docs
+
+- The image source: <https://github.com/leverj/security-scanner>
+- The spec: `security-scan-spec.md` in that repo (data model, fingerprint
+  scheme, dedup invariants).
+- The image's manifest: read at runtime with
+  `docker run --rm --entrypoint cat leverj/security-scan:<tag> /app/SECURITY-SCAN-MANIFEST.yaml`.

--- a/skills/security-scan/SKILL.md
+++ b/skills/security-scan/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Run the security-scan scanner against a repo via the published
   `leverj/security-scan` Docker image. Detects the repo's tech stack, runs
   OSV-Scanner, Gitleaks, Semgrep, Trivy, Trufflehog (and optionally LLM-driven
-  Codex + Gemma SAST with bidirectional cross-validation), and files each
-  finding into a GitHub Projects v2 board. On every run, checks Docker Hub for
-  a newer image and — on user confirmation — pulls it and applies any new
+  Codex + Gemma SAST with bidirectional cross-validation), scans base-image
+  CVEs, and runs Supabase live-DB advisor queries. Files each finding into a
+  GitHub Projects v2 board. On every run, checks Docker Hub for a newer image
+  DIGEST and — on user confirmation — pulls it and applies any new
   config-schema migrations declared in the image's SECURITY-SCAN-MANIFEST.yaml.
   Use when the user says "scan", "/security-scan", "run security-scan",
   "scan this repo for security issues", "check for secrets / CVEs / SAST
@@ -24,7 +25,7 @@ per-deployment state lives in a **config directory** (defaults to
 Between runs the skill keeps two small files in the user's config dir:
 
 - `config.yaml`                — the live config (the unit of configuration).
-- `.security-scan-state.yaml`  — managed by the skill; tracks pinned image tag.
+- `.security-scan-state.yaml`  — managed by the skill; tracks the pinned image **digest**.
 
 This skill never writes inside the image. It only:
 
@@ -32,7 +33,24 @@ This skill never writes inside the image. It only:
 2. Bind-mounts the user's config dir at `/config:ro`,
 3. Reads the image's `/app/SECURITY-SCAN-MANIFEST.yaml` to learn what version
    is inside and what config fields it expects,
-4. Drives `docker run` with the right flags.
+4. Drives `docker run` with the right flags — pinning by **digest**, not tag.
+
+## Why digest, not tag
+
+The image is published as `leverj/security-scan:latest` only. There are no
+versioned tags accumulating on Docker Hub — each push of `:latest` is a new
+immutable manifest with a new SHA-256 digest. The skill tracks that digest as
+the unit of identity:
+
+- The skill pins to the digest in `pinned_digest`.
+- "Has it updated?" → fetch the current `:latest` digest from Docker Hub,
+  compare. If different, surface the version label (from the new image's
+  manifest) and ask the user.
+- The actual `docker run` uses `leverj/security-scan@sha256:<digest>` so even
+  if `:latest` moves mid-run, the pin holds.
+
+The `version` field inside the manifest is a human-readable label
+(`"0.3.2"`) used only for the upgrade prompt — image identity is the digest.
 
 ## Invocation
 
@@ -48,7 +66,7 @@ This skill never writes inside the image. It only:
 Flags accepted on every subcommand:
 
 - `--config-dir <path>` — use a non-default config dir (default `~/.security-scan`).
-- `--no-update-check`   — skip the pre-run Docker Hub check (faster; offline-OK).
+- `--no-update-check`   — skip the pre-run Docker Hub digest check (faster; offline-OK).
 - `--image <ref>`       — override `leverj/security-scan` (e.g., for a fork).
 
 ## Phase-by-phase operating procedure
@@ -68,53 +86,73 @@ If the chosen directory doesn't contain `config.yaml`:
 - For everything else: stop and tell the user to run
   `/leverj:security-scan setup`.
 
-### Phase 1 — Resolve pinned image tag
+### Phase 1 — Resolve pinned image digest
 
 Read `<config-dir>/.security-scan-state.yaml`. Expected shape:
 
 ```yaml
-pinned_tag: "0.2.0"
-pinned_digest: "sha256:abc..."
-image: "leverj/security-scan"
-last_checked: "2026-06-02T12:00:00Z"
+pinned_digest: "sha256:abc123..."          # canonical identity (immutable)
+version_label: "0.3.2"                     # for display only (from manifest.version)
+image:         "leverj/security-scan"      # in case user pointed at a fork
+last_checked:  "2026-06-02T12:00:00Z"      # ISO 8601 UTC; controls the 6h throttle
+last_upgrade:  "2026-06-02T11:55:00Z"      # most recent successful upgrade
 ```
 
-If the state file is missing or has no `pinned_tag`, treat as **first run**:
-proceed to Phase 2 to pick the latest tag, then continue.
+If the state file is missing or has no `pinned_digest`, treat as **first run**:
+proceed to Phase 2 to discover the current `:latest` digest, then continue.
 
-### Phase 2 — Check for image updates
+### Phase 2 — Check for image updates (digest-based)
 
-Skip this phase if `--no-update-check` was passed or if the last check was
-less than 6 hours ago (cheap throttle to avoid hammering Docker Hub on rapid
+Skip this phase if `--no-update-check` was passed or if `last_checked` is less
+than 6 hours ago (cheap throttle to avoid hammering Docker Hub on rapid
 re-runs).
 
-1. Query Docker Hub for the most recent tag:
-   ```bash
-   curl -fsSL "https://hub.docker.com/v2/repositories/leverj/security-scan/tags?page_size=10&ordering=last_updated" \
-     | jq -r '.results[].name' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1
-   ```
-2. Normalize: strip a leading `v` for comparison; both `v0.2.0` and `0.2.0` are
-   accepted. The manifest's `version` is canonical (no `v` prefix).
-3. Compare to the pinned tag:
-   - If equal → no update; record `last_checked` and continue to Phase 3.
-   - If different → fetch the new image's manifest (Phase 2a).
+Fetch the current digest of `:latest` without pulling:
+
+```bash
+# Primary: Docker Hub REST API. Returns the manifest digest of :latest.
+LATEST_DIGEST=$(
+  curl -fsSL "https://hub.docker.com/v2/repositories/leverj/security-scan/tags/latest/" \
+    | jq -r '.digest // .images[0].digest // empty'
+)
+
+# Fallback if the REST API fails: ask the daemon (requires login to be set up
+# for private repos, but our image is public).
+if [ -z "$LATEST_DIGEST" ]; then
+  LATEST_DIGEST=$(docker manifest inspect leverj/security-scan:latest \
+    | jq -r '.manifests[0].digest // .config.digest // empty')
+fi
+```
+
+The shape varies: tags API returns `sha256:...` directly; manifest inspect
+returns a JSON with `manifests[]` (multi-arch index) or `config.digest`
+(single-arch). For our multi-arch image, take the **index digest** (top-level
+`digest` from the tags API, or compute it from the manifest list) — that's
+what `docker pull` resolves to and what we pin against.
+
+Compare to `pinned_digest`:
+
+- If equal → no update; record `last_checked` and continue to Phase 3.
+- If different → fetch the new image's manifest (Phase 2a).
+- If pinned_digest is missing (first run) → treat as an upgrade from "none".
 
 #### Phase 2a — Inspect the candidate image's manifest
 
-Pull the metadata WITHOUT replacing the user's pinned image yet:
+Pull the metadata WITHOUT replacing the user's pinned image yet. Because the
+image is content-addressed, we can pull by digest directly:
 
 ```bash
-# Pull just enough to read the manifest. `cat` is the entrypoint override.
-docker pull -q "leverj/security-scan:${CANDIDATE_TAG}"
+docker pull -q "leverj/security-scan@${LATEST_DIGEST}"
 docker run --rm --entrypoint cat \
-  "leverj/security-scan:${CANDIDATE_TAG}" /app/SECURITY-SCAN-MANIFEST.yaml \
-  > /tmp/security-scan-manifest-${CANDIDATE_TAG}.yaml
+  "leverj/security-scan@${LATEST_DIGEST}" /app/SECURITY-SCAN-MANIFEST.yaml \
+  > /tmp/security-scan-manifest-${LATEST_DIGEST##*:}.yaml
 ```
 
 Parse the manifest with `yq` (or fall back to a `python3 -c` one-liner if
 `yq` isn't on PATH). Surface to the user:
 
-- The version delta (e.g., `0.1.0 → 0.2.0`).
+- The version-label delta (e.g., `0.2.4 → 0.3.2`) AND the digest delta
+  (`sha256:abc...→sha256:def...`).
 - The `changelog` lines as a bullet list.
 - A summary of `breaking_changes` if any (each is `id + summary + user_action`).
 - A summary of pending config changes:
@@ -122,18 +160,23 @@ Parse the manifest with `yq` (or fall back to a `python3 -c` one-liner if
   - `renamed_fields` where the old name is in their `config.yaml` → "the skill will RENAME these in place".
   - `removed_fields` present in their `config.yaml` → "the skill will REMOVE these (with confirmation)".
 
+If the current schema version (`config_schema_version` in the new manifest)
+is greater than what the user's config was migrated to, mention it explicitly
+so the user knows new fields may appear.
+
 #### Phase 2b — Ask for confirmation
 
 Print a clear yes/no prompt. If `breaking_changes` is non-empty, require an
 explicit `yes` (not just `y`). If no breaking changes, a plain `y` suffices.
 
 If the user declines:
-- Keep the current pinned tag.
+- Keep the current pinned digest.
 - Record `last_checked` (so the throttle kicks in next time).
 - Continue to Phase 3 with the old image.
 
 If the user accepts:
-- Write the new pinned tag + digest to `.security-scan-state.yaml`.
+- Write the new `pinned_digest` + `version_label` to `.security-scan-state.yaml`.
+- Update `last_upgrade` to now.
 - Apply config migrations (Phase 2c).
 
 #### Phase 2c — Apply config migrations
@@ -165,6 +208,8 @@ For `secrets.source: env`:
 - `GITHUB_TOKEN` must be exported in the current shell.
 - If `slack.enabled: true`, the var named by `slack.webhook_url_env` (or
   `channel_id_env` + `bot_token_env`) must be exported.
+- If `supabase.enabled: true`, the var named by `supabase.url_env` (or all of
+  `host_env`/`db_env`/`user_env`/`password_env`) must be exported.
 
 For `secrets.source: 1password`:
 - `op` must be on `PATH` and `op account list` must succeed (signed-in).
@@ -180,12 +225,16 @@ If any check fails, surface a clear remediation and stop.
 
 ### Phase 4 — Run
 
+Invoke by **digest**, not tag — so the pin survives a concurrent `:latest`
+push from the publisher.
+
 ```bash
 docker run --rm \
   -v "${CONFIG_DIR}:/config:ro" \
   -e GITHUB_TOKEN \
   $([ "${SLACK_FORWARDED}" ] && echo -e SLACK_WEBHOOK_URL) \
-  "leverj/security-scan:${PINNED_TAG}" \
+  $([ "${SUPABASE_FORWARDED}" ] && echo -e SUPABASE_DB_URL) \
+  "${IMAGE}@${PINNED_DIGEST}" \
   $([ -z "${NO_DRY_RUN}" ] && echo --dry-run)
 ```
 
@@ -209,6 +258,9 @@ After the container exits, surface to the user:
    `https://github.com/orgs/<project.owner>/projects/<project.number>`.
 4. The dry-run / real-run mode, explicitly stated.
 5. If `--no-dry-run` was passed, the count of issues actually filed.
+6. If the run found findings under `category: image` or `category: config`,
+   mention them by category count — these are newer lanes (image-CVE scanning
+   and the live Supabase advisor) the user may not be expecting.
 
 DO NOT paste the full stderr log into your reply — it can be hundreds of
 lines. Quote relevant excerpts only.
@@ -218,30 +270,40 @@ lines. Quote relevant excerpts only.
 Triggered by `/leverj:security-scan setup` or when Phase 0 finds no config.
 
 1. `mkdir -p ~/.security-scan`.
-2. Pull the latest image: `docker pull leverj/security-scan:latest`.
-3. Read the image's manifest with
-   `docker run --rm --entrypoint cat leverj/security-scan:latest /app/SECURITY-SCAN-MANIFEST.yaml`.
-4. Use the manifest's `config.new_fields` (where `required: true`) as the
+2. Fetch the current `:latest` digest (Phase 2 logic).
+3. Pull by digest: `docker pull leverj/security-scan@${LATEST_DIGEST}`.
+4. Read the image's manifest with
+   `docker run --rm --entrypoint cat leverj/security-scan@${LATEST_DIGEST} /app/SECURITY-SCAN-MANIFEST.yaml`.
+5. Use the manifest's `config.new_fields` (where `required: true`) as the
    prompt schema. Ask the user for each required value:
    - `repo` (e.g., `leverj/ezel`)
    - `ref` (default `main`)
    - `project.owner` (org or user)
    - `project.number` (project number from the URL)
-5. Ask which secret path: env (default) or 1password. If 1password, also ask
+6. Ask which secret path: env (default) or 1password. If 1password, also ask
    for the env file path.
-6. Write `~/.security-scan/config.yaml` with the required fields filled in
+7. Write `~/.security-scan/config.yaml` with the required fields filled in
    and the optional ones at their documented defaults.
-7. If `secrets.source: 1password`, copy the image-baked example to
+8. If `secrets.source: 1password`, copy the image-baked example to
    `~/.security-scan/.env.1password.tpl` and tell the user to edit it with
    their `op://vault/item/...` paths. Get the template contents with:
    ```bash
    docker run --rm --entrypoint cat \
-     leverj/security-scan:latest /app/config/.env.1password.tpl.example
+     leverj/security-scan@${LATEST_DIGEST} /app/config/.env.1password.tpl.example
    ```
-8. Tell the user the PAT scopes required (`repo` + `project`) and where to
-   create one.
-9. Run Phase 3 (verify) to confirm everything's wired.
-10. Run a dry-run (Phase 4 with `--dry-run`) and report (Phase 5).
+9. Ask whether the user wants the **optional opt-in lanes** enabled:
+   - `image_scan.built_image.enabled` (scan a pulled or locally-built image —
+     defaults off; surface the security implications if they say yes).
+   - `supabase.enabled` (live Supabase Postgres advisor — requires a
+     read-only DB role; surface the recommended `CREATE ROLE` + `GRANT`).
+   - `scanners.codex` / `scanners.gemma` (LLM-driven SAST; explain costs).
+   These are all defaulted off in the manifest's `new_fields`.
+10. Tell the user the PAT scopes required (`repo` + `project`) and where to
+    create one.
+11. Write `.security-scan-state.yaml` with the resolved `pinned_digest` and
+    `version_label` from the manifest.
+12. Run Phase 3 (verify) to confirm everything's wired.
+13. Run a dry-run (Phase 4 with `--dry-run`) and report (Phase 5).
 
 ## Hard rules
 
@@ -251,8 +313,9 @@ These are non-negotiable. They protect the user and the source of truth.
   current turn.** The default is dry-run for a reason — security-scan files
   real GitHub issues. Surprise filings are a trust violation.
 - **NEVER include secrets in your replies.** `GITHUB_TOKEN`, 1Password env
-  file contents, Slack webhooks must never appear in your messages.
-  security-scan scrubs these from its own logs; you must scrub yours.
+  file contents, Slack webhooks, Supabase DSNs / passwords must never appear
+  in your messages. security-scan scrubs these from its own logs; you must
+  scrub yours.
 - **NEVER edit `config.yaml` silently.** Every change (new field added,
   renamed, removed) MUST be shown as a diff and confirmed before writing.
 - **NEVER edit the image.** The skill drives a published image; you don't
@@ -264,14 +327,23 @@ These are non-negotiable. They protect the user and the source of truth.
   triage is a separate workflow (`/leverj:triage`).
 - **Honor `--no-update-check`.** Skip the Docker Hub probe entirely; don't
   try to be clever and check anyway "just in case".
+- **Pin by digest, run by digest.** `docker run leverj/security-scan:latest`
+  is wrong — between Phase 2's check and Phase 4's run, `:latest` could
+  move. Always invoke `leverj/security-scan@${PINNED_DIGEST}`.
+- **NEVER enable `image_scan.built_image.build_locally` without explicit
+  per-run consent.** That mode `docker build`s the cloned repo, which
+  executes the repo's Dockerfile RUN lines and requires both the docker
+  socket mounted and `SECURITY_SCAN_ALLOW_BUILD=1` in env. It's the one
+  carve-out to security-scan's otherwise-strict "never execute repo code"
+  invariant.
 
 ## Notes on the `.security-scan-state.yaml` file
 
 The skill owns this file. Users don't edit it by hand. Recognized keys:
 
 ```yaml
-pinned_tag:    "0.2.0"                # the docker tag in use
-pinned_digest: "sha256:abc..."        # immutable digest for reproducibility
+pinned_digest: "sha256:abc..."        # canonical identity; this is THE pin
+version_label: "0.3.2"                # human-readable, from manifest.version
 image:         "leverj/security-scan" # in case user pointed at a fork
 last_checked:  "2026-06-02T12:00:00Z" # ISO 8601 UTC; controls the 6h throttle
 last_upgrade:  "2026-06-02T11:55:00Z" # records the most recent successful upgrade
@@ -280,6 +352,11 @@ last_upgrade:  "2026-06-02T11:55:00Z" # records the most recent successful upgra
 Re-creating it from scratch is safe — Phase 1 detects the missing file and
 treats it as a first run.
 
+If a user's state file from a pre-digest version has `pinned_tag` but no
+`pinned_digest`, treat as a first run and re-resolve. Don't try to map the
+old tag to a digest — Docker Hub may not have it anymore (we only publish
+`:latest`).
+
 ## When something goes wrong
 
 | Symptom | Likely cause | Fix |
@@ -287,11 +364,15 @@ treats it as a first run.
 | `docker: command not found` | Docker not installed | Tell user to install Docker Desktop |
 | `Cannot connect to the Docker daemon` | Docker not running | Tell user to start Docker Desktop |
 | `pull access denied` | Image name typo or private repo | Verify `image` in state.yaml is `leverj/security-scan` |
+| Hub REST API returns 404 on `tags/latest/` | First publish hasn't happened, or `:latest` was retracted | Fall back to `docker manifest inspect`; if that also fails, stop and tell the user the image isn't published yet |
 | `secrets env file not found` | 1Password path missing | Run `setup` again or copy the example |
 | `op not signed in` | 1Password CLI logged out | `op signin` in the user's shell, then retry |
 | `GitHub API 404: project not found` | Wrong owner/number OR PAT missing `project` scope | Verify project URL + PAT scopes |
-| `scanners completed: 0` and several failures | Network or image corruption | Re-pull the image, re-run |
-| Schema mismatch on manifest read | Older image with no manifest | Pin to a known-good tag in state.yaml; old images don't have the manifest contract |
+| `scanners completed: 0` and several failures | Network or image corruption | Re-pull the image by digest, re-run |
+| Schema mismatch on manifest read | Older image with no manifest | Tell the user the pinned image predates the manifest contract; recommend re-running `setup` to discover the current `:latest` |
+| `supabase: all checks failed: ... permission denied` | DB role lacks `pg_read_all_data` | Re-run the recommended `GRANT` statements from the setup phase |
+| `image:python:3.14 — exit 1: trivy: vulnerability DB locked` | Concurrent trivy run in the same container | Re-run; the DB lock clears on restart |
+| `image_scan.built_image: SECURITY_SCAN_ALLOW_BUILD=1` required | User enabled `build_locally` without the env guard | This is intentional; only set `SECURITY_SCAN_ALLOW_BUILD=1` if the cloned repo is trusted, since `docker build` will execute its RUN lines |
 
 ## Companion docs
 
@@ -299,4 +380,4 @@ treats it as a first run.
 - The spec: `security-scan-spec.md` in that repo (data model, fingerprint
   scheme, dedup invariants).
 - The image's manifest: read at runtime with
-  `docker run --rm --entrypoint cat leverj/security-scan:<tag> /app/SECURITY-SCAN-MANIFEST.yaml`.
+  `docker run --rm --entrypoint cat leverj/security-scan@<digest> /app/SECURITY-SCAN-MANIFEST.yaml`.


### PR DESCRIPTION
## Summary

Adds the \`security-scan\` skill that drives the published \`leverj/security-scan\` Docker image. Includes the recent updates from this session to:

- Match the **digest-based** identity contract (image is published as \`:latest\` only; the skill tracks/pins the digest).
- Surface the v3 schema additions: \`image_scan\` (Dockerfile FROM scanning + opt-in built/pulled image scanning) and \`supabase\` (live Postgres advisor lane).

## What the skill does

1. **Locates** a config directory (defaults \`~/.security-scan/\`).
2. **Resolves** the pinned image digest from \`.security-scan-state.yaml\`.
3. **Checks Docker Hub** for a newer \`:latest\` digest (throttled to 6h; skippable with \`--no-update-check\`).
4. On a new digest, **reads the image's \`/app/SECURITY-SCAN-MANIFEST.yaml\`**, shows the changelog + breaking-changes + config migrations, and asks for confirmation. Applies \`new_fields\` / \`renamed_fields\` / \`removed_fields\` to the user's \`config.yaml\` (with a \`.bak\` and a diff).
5. **Verifies** secrets + config (env or 1Password).
6. **Runs** the image by digest with the config dir bind-mounted read-only. Defaults to \`--dry-run\`.
7. **Reports** the summary + project board link, calling out new \`category: image\` and \`category: config\` finding counts.

## Why digest, not tag

The image is now published as \`:latest\` only — no versioned tags accumulate on Docker Hub. Each push of \`:latest\` is a new immutable manifest. The skill pins to the digest, so:
- \`docker run\` always uses \`leverj/security-scan@<digest>\` — survives a concurrent \`:latest\` push.
- "Has it updated?" → fetch current \`:latest\` digest, compare.
- The \`version\` field in the manifest is human-readable only.

## Files

- \`skills/security-scan/SKILL.md\` (new + updated): phase-by-phase operating procedure, hard rules, troubleshooting table.
- \`.claude-plugin/marketplace.json\`: registers the skill; version 0.5.0 → 0.5.1.
- \`README.md\` (already includes the row from the prior session).

## Test plan

- [ ] \`/leverj:security-scan setup\` against a fresh \`~/.security-scan/\` — verify it reads the image manifest, prompts for required fields, writes config + state files.
- [ ] \`/leverj:security-scan\` (= \`run\`) with the state already populated — verify it pins by digest, runs dry-run, reports.
- [ ] \`/leverj:security-scan upgrade\` after a new image publish — verify the diff + confirmation + state-file rewrite.
- [ ] \`/leverj:security-scan check\` — verify the no-op verification path.
- [ ] Confirm \`leverj/security-scan:latest\` is published first; otherwise the digest fetch returns 404.

## Requires

The first usable run requires \`leverj/security-scan:latest\` to be published with v0.3.2 (or any v0.3.x). Today's \`:latest\` on Docker Hub is the pre-image-scan/supabase release, so the upgrade flow's manifest-migration path is not yet exercised end-to-end. Run \`./security-scan.sh publish\` in the \`leverj/security-scanner\` repo to bring \`:latest\` current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)