### PR TITLE
fix(security-scan-llm): unblock the LLM lane end-to-end (codex schema + normalize arg order)

### DIFF
--- a/tools/security-scan-llm/security_scan_llm/cli.py
+++ b/tools/security-scan-llm/security_scan_llm/cli.py
@@ -182,7 +182,7 @@ def run(
 
 def _absorb(r: RunnerResult, findings: list[Finding], completed: list[str], failed: list[tuple[str, str]]) -> None:
     if r.completed and r.sarif:
-        norm = normalize_sarif(r.scanner, r.sarif)
+        norm = normalize_sarif(r.sarif, r.scanner)
         findings.extend(norm)
         completed.append(r.scanner)
         print(f"  -> {r.scanner}: {len(norm)} finding(s)", file=sys.stderr)

--- a/tools/security-scan-llm/security_scan_llm/runners/codex.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/codex.py
@@ -39,19 +39,21 @@ _SEVERITY_TO_LEVEL = {
     "info":     "note",
 }
 
-# JSON schema for codex's structured output. The schema is strict by design —
-# extra fields are allowed (Codex sometimes adds them) but the required ones must be present.
+# JSON schema for codex's structured output. OpenAI strict structured-output
+# (response_format json_schema) rejects the request unless every object sets
+# additionalProperties:false AND lists every property key in `required` —
+# optional fields are expressed as nullable types, not as omitted-from-required.
 _SCHEMA: dict = {
     "type": "object",
-    "additionalProperties": True,
+    "additionalProperties": False,
     "required": ["findings"],
     "properties": {
         "findings": {
             "type": "array",
             "items": {
                 "type": "object",
-                "additionalProperties": True,
-                "required": ["file", "rule_id", "severity", "title", "message"],
+                "additionalProperties": False,
+                "required": ["file", "line", "rule_id", "severity", "title", "message", "snippet"],
                 "properties": {
                     "file":     {"type": "string"},
                     "line":     {"type": ["integer", "null"]},


### PR DESCRIPTION
Two latent bugs blocked the host LLM lane (codex + gemma) from ever filing a finding. The first hid the second — codex never produced output, so the normalize crash never fired.

## Bug 1 — codex output schema not strict-mode compliant

The codex lane failed every run with a misleading `codex auth failed` message. Auth was fine; the runner's loose error matcher (`"auth" in err.lower()`) mislabeled a `400 invalid_request_error`.

`_SCHEMA` (passed to `codex exec --output-schema`) violated OpenAI strict structured-output on current Codex CLI (0.136.0 / gpt-5.5):
- `additionalProperties` must be `false` on every object (root + `findings.items`) — was `true`.
- `required` must list **every** key in `properties`; optional fields are nullable types, not omitted — `line` and `snippet` were missing.

Every request 400'd before output. Fixed by tightening `_SCHEMA`.

## Bug 2 — `normalize_sarif` called with swapped args

`_absorb` called `normalize_sarif(r.scanner, r.sarif)` but the signature is `normalize_sarif(sarif, scanner, ...)`. The SARIF dict landed in the `scanner` param and hit `scanner not in _CATEGORY` → `TypeError: unhashable type: 'dict'`. Affected both codex and gemma. Fixed the arg order.

## Verification

- Old schema reproduced the `400 invalid_json_schema`; new schema → codex returns valid output.
- `codex.run()` against a planted `os.system(cmd)` injection: `completed=True, findings=1`.
- Full path in dry-run with a synthetic finding: `normalize_sarif` → `resolve_project` (live) → `sync` all succeed, producing a correctly-labeled, fingerprinted issue payload.

## Not addressed (pre-existing, out of scope)

- Loose `"auth" in err.lower()` matcher should surface the real codex error.
- Runner forwards full `os.environ` to the codex subprocess.
- `extra_args` appended without flag-injection validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)