### PR TITLE
feat(security-scan-llm): generic lanes — any backend/model, N lanes, auto-migrate

### DIFF
--- a/skills/security-scan-llm/SKILL.md
+++ b/skills/security-scan-llm/SKILL.md
@@ -188,33 +188,34 @@ Run a non-destructive check before invoking the tool.
 
 2. **PAT**: env var named by `github_token_env` is set + non-empty.
 
-3. **At least one LLM lane enabled**: if `scanners.codex`, `scanners.claude`
-   and `scanners.gemma` are all false, stop with a clear message — the tool
-   will error otherwise. (Cross-validation needs **two** lanes; with only one
-   enabled, it's a no-op.)
+3. **At least one lane configured**: read `lanes:` (or, on a legacy file, the
+   `scanners:` toggles the tool will auto-migrate). If there are zero lanes,
+   stop — the tool errors otherwise. (Cross-validation needs **two** lanes;
+   with one, it's a no-op.) Each lane's `backend` is `codex-cli`,
+   `claude-cli`, or `ollama`; health-check each lane by its backend:
 
-4. **Codex health** (if `scanners.codex: true`):
+4. **codex-cli lane health** (for each lane with `backend: codex-cli`):
    ```bash
    command -v codex >/dev/null || { echo "codex CLI not on PATH"; FAIL=1; }
    codex login status >/dev/null 2>&1 || { echo "codex not logged in — run 'codex login'"; FAIL=1; }
    ```
-   If either fails: surface clearly and ask whether to proceed with the other
-   enabled lane(s) (silently) or stop.
+   If it fails: surface clearly and ask whether to proceed with the other
+   lane(s) or stop.
 
-5. **Claude health** (if `scanners.claude: true`):
+5. **claude-cli lane health** (for each lane with `backend: claude-cli`):
    ```bash
    command -v claude >/dev/null || { echo "claude CLI not on PATH"; FAIL=1; }
    # Subscription auth (no API key). A non-empty oauthAccount in ~/.claude.json
    # means logged in; an ANTHROPIC_API_KEY in env would route to metered API.
    ```
    If `claude` is missing, surface clearly and ask whether to proceed with the
-   other enabled lane(s) or stop. The lane uses the user's Claude Max/Pro
-   subscription — flag that a full audit draws the same usage pool as their
-   interactive Claude Code sessions.
+   other lane(s) or stop. The lane uses the user's Claude Max/Pro subscription —
+   flag that a full audit draws the same usage pool as their interactive
+   Claude Code sessions.
 
-6. **Gemma / Ollama health** (if `scanners.gemma: true`):
+6. **ollama lane health** (for each lane with `backend: ollama`):
    ```bash
-   BASE_URL="$(yq '.gemma.base_url' "${CFG}" 2>/dev/null || echo http://localhost:11434)"
+   BASE_URL="<lane.base_url, default http://localhost:11434>"
    curl -fsS "${BASE_URL%/}/api/tags" >/dev/null \
      || { echo "Ollama unreachable at ${BASE_URL}"; FAIL=1; }
    ```
@@ -271,23 +272,24 @@ relative to that.
    - `ref` — default: `main`.
    - `project.owner`, `project.number` — required from user.
    - `github_token_env` — default: `GITHUB_TOKEN`.
-5. **Lane prompts:**
-   - `scanners.codex: true/false` — default false. **Surface:** uses your
-     ChatGPT/Codex subscription quota; each run can consume several minutes
-     of model time.
-   - `scanners.claude: true/false` — default false. **Surface:** uses your
-     Claude Max/Pro subscription (the local `claude` CLI; no API key). A full
-     audit draws the same usage pool as the user's interactive Claude Code
-     sessions. Offer to pin `claude.model` (e.g. `claude-sonnet-4-6` for a
-     lighter usage footprint than Opus).
-   - `scanners.gemma: true/false` — default false. **Surface:** uses your
-     local Ollama (must be running); first run can take minutes for the
-     model to warm. Source files cross the loopback boundary to Ollama;
-     `gemma.base_url` must be loopback or RFC1918. Heavy on small hosts —
-     a 26B model needs a box with headroom well above its weight.
-6. **Cross-validate prompt** (only if ≥2 lanes enabled): `cross_validate.enabled`
-   — default true. **Surface:** each finding is reviewed by a different
-   enabled lane; reduces false positives but adds an LLM call per finding.
+5. **Lane prompts:** build the `lanes:` list. Each lane = `{name, backend,
+   model, ...}`. Offer these backends (default two-lane setup: codex + claude):
+   - **`codex-cli`** — uses the ChatGPT/Codex subscription via the local
+     `codex` CLI. Each run can consume several minutes of model time.
+   - **`claude-cli`** — uses the Claude Max/Pro subscription via the local
+     `claude` CLI (no API key). A full audit draws the same usage pool as the
+     user's interactive Claude Code sessions. Offer to pin `model`
+     (e.g. `claude-sonnet-4-6` for a lighter footprint than Opus).
+   - **`ollama`** — any local Ollama model (`model:` picks it, e.g.
+     `qwen2.5-coder:32b`, `gemma4:26b`). Ollama must be running; first run
+     warms the model. Source files cross the loopback boundary, so `base_url`
+     must be loopback or RFC1918. Heavy on small hosts — a 20B+ model needs a
+     box with real headroom.
+   Each lane's `name` is its scanner label / rule-id prefix, so it must be
+   unique. Aim for **two** lanes so cross-validation has something to compare.
+6. **Cross-validate prompt** (only if ≥2 lanes): `cross_validate.enabled`
+   — default true. **Surface:** each finding is reviewed by a different lane;
+   reduces false positives but adds an LLM call per finding.
 7. **Triage prompt:** `triage.enabled: true/false` — default false.
    - If true, sub-prompts: `intro_enabled` (default true, cheap),
      `prose_enabled` (default false, 1 call per finding), `fuzzy_dup_enabled`
@@ -313,12 +315,12 @@ These are non-negotiable.
   diff and confirmed before writing.
 - **NEVER `pipx install` or `pip upgrade` the tool for the user.** Surface
   the command; let them run it. Package installs touch their Python env.
-- **Refuse non-loopback `gemma.base_url`.** Source content over a public
-  boundary is a policy violation. The tool refuses too; the skill catches it
-  earlier with a clearer message.
-- **Refuse to run with every lane off** (`scanners.codex`, `scanners.claude`
-  and `scanners.gemma` all false). Stop at Phase 3; tell the user to enable
-  at least one lane (two for cross-validation to do anything).
+- **Refuse a non-loopback `base_url` on any `ollama` lane.** Source content
+  over a public boundary is a policy violation. The tool refuses too; the
+  skill catches it earlier with a clearer message.
+- **Refuse to run with no lanes** (`lanes:` empty and no legacy `scanners:`
+  to migrate). Stop at Phase 3; tell the user to configure at least one lane
+  (two for cross-validation to do anything).
 - **The Projects v2 board is the source of triage truth.** Don't try to
   dedup findings yourself; that's the tool's job (deterministic
   fingerprints in the issue body, byte-identical to the static lane's).
@@ -348,7 +350,7 @@ lockfile); leaving it out lets each developer track their own install.
 | `claude CLI not on PATH` | claude CLI isn't installed | install Claude Code; run `claude` once to log in (subscription) |
 | `claude` lane bills the API instead of the subscription | `ANTHROPIC_API_KEY` set in env | unset it so `claude` uses the OAuth subscription session |
 | `Ollama unreachable at http://localhost:11434` | Ollama not running | start Ollama daemon |
-| `Refusing to send source to non-local Ollama` | `gemma.base_url` is a public host | set to `http://localhost:11434` |
+| `Refusing to send source to non-local Ollama` | an `ollama` lane's `base_url` is a public host | set to `http://localhost:11434` |
 | `SOCKET_API_KEY env unset` | (this is the static lane's job, not this skill's) | this skill doesn't use Socket; see `/leverj:security-scan` |
 | Findings double-filed across substrates | mismatched fingerprint scheme | open an issue — the fingerprint MUST be byte-identical between substrates |
 

--- a/tools/security-scan-llm/README.md
+++ b/tools/security-scan-llm/README.md
@@ -62,25 +62,30 @@ project:
   number: 7
 github_token_env: "GITHUB_TOKEN"   # PAT with repo + project scopes
 
-scanners:
-  codex:  true        # opt-in (cloud, ChatGPT/Codex subscription)
-  claude: true        # opt-in (cloud, Claude Max/Pro subscription)
-  gemma:  false       # opt-in (local Ollama; heavy on small hosts)
+# Each lane is an LLM that scans the repo; any two lanes cross-reference each
+# other. `name` = the scanner label / rule-id prefix. `backend` is one of
+# codex-cli | claude-cli | ollama.
+lanes:
+  - name: codex            # cloud, ChatGPT/Codex subscription
+    backend: codex-cli
+    model: null            # null => the codex CLI default
+  - name: claude           # cloud, Claude Max/Pro subscription
+    backend: claude-cli
+    model: claude-sonnet-4-6
+  - name: qwen             # any local Ollama model, labeled `qwen.*`
+    backend: ollama
+    model: qwen2.5-coder:32b
+    base_url: "http://localhost:11434"   # MUST be loopback or RFC1918
 
-# Optional tunables (defaults shown — omit any you're happy with)
-codex:
-  binary: "codex"
-claude:
-  binary: "claude"
-  model:  "claude-sonnet-4-6"   # null => the claude CLI's default
-gemma:
-  base_url: "http://localhost:11434"   # MUST be loopback or RFC1918
-  model:    "gemma4:26b"
 cross_validate:
-  enabled: true       # each finding reviewed by a different lane (when ≥2 lanes on)
+  enabled: true       # each finding reviewed by a different lane (when ≥2 lanes)
 triage:
-  enabled: false      # gemma-driven issue prose / slack intro / fuzzy-dedup
+  enabled: false      # ollama-driven issue prose / slack intro / fuzzy-dedup
 ```
+
+> **Legacy configs auto-migrate.** A pre-0.3 file using `scanners:` +
+> `codex:`/`claude:`/`gemma:` blocks is converted to lanes at load time (with a
+> one-line notice) — no edit required. New files should use `lanes:`.
 
 Full schema: see [SECURITY-SCAN-LLM-MANIFEST.yaml](./SECURITY-SCAN-LLM-MANIFEST.yaml).
 
@@ -100,8 +105,8 @@ Failure modes:
 | Cause | Behavior |
 |---|---|
 | `codex` / `claude` binary missing or not logged in | That lane returns `completed=False`; the other lanes continue. |
-| Ollama unreachable at `gemma.base_url` | That lane returns `completed=False`. |
-| No LLM lane enabled (`scanners.codex` / `claude` / `gemma` all false) | Exit 2 with a clear error — nothing to do. |
+| Ollama unreachable at an `ollama` lane's `base_url` | That lane returns `completed=False`. |
+| No lanes configured (`lanes:` empty / missing, no legacy `scanners:` either) | Exit 2 with a clear error — nothing to do. |
 | GitHub PAT missing `project` scope | Exit 4 with the GitHub API error. |
 | All enabled lanes failed | Exit 3. |
 

--- a/tools/security-scan-llm/SECURITY-SCAN-LLM-MANIFEST.yaml
+++ b/tools/security-scan-llm/SECURITY-SCAN-LLM-MANIFEST.yaml
@@ -19,17 +19,21 @@
 #    paths, slack, github_token_env) are duplicated rather than imported —
 #    each tool owns its own contract.
 
-version: "0.2.0"
-config_schema_version: 1
+version: "0.3.0"
+config_schema_version: 2
 tool_name: "security-scan-llm"
 released: "2026-06-03"
 
 # One-liners for the upgrade prompt the skill shows users.
 changelog:
+  - "0.3.0: GENERIC LANES. Replace the fixed `scanners:` toggles + per-backend `codex:`/`claude:`/`gemma:` blocks with a `lanes:` list — each lane picks a `backend` (codex-cli / claude-cli / ollama) and a `model`, and its `name` becomes the scanner label / rule prefix. Any two lanes cross-reference each other, any Ollama model is a first-class lane, and N lanes are allowed. Legacy `scanners:` configs are auto-migrated at load time (no edit required)."
   - "0.2.0: add the Claude SAST lane (`scanners.claude`, uses the local `claude` CLI on a Max/Pro subscription) and make cross-validation lane-agnostic — any two of codex/claude/gemma now review each other. Fixes codex strict-output-schema and a normalize arg-order crash that previously blocked the LLM lanes from filing."
   - "0.1.0: initial release. Host-side LLM lane (codex + gemma + bidirectional cross-validation) for the leverj security-scan pipeline. Reads `<repo>/.security-scan/config-llm.yaml`. Files findings into the same Projects v2 board as the deterministic container, dedup'd via a byte-identical fingerprint scheme."
 
-breaking_changes: []
+breaking_changes:
+  - id: "lanes-list-replaces-scanners"
+    summary: "Config schema v2: `scanners:` toggles and the `codex:`/`claude:`/`gemma:` blocks are replaced by a single `lanes:` list. Per-lane cross-validate timeouts move from `cross_validate.<lane>_timeout` to each lane's `validate_timeout`."
+    user_action: "No action required to keep running — the tool auto-migrates a legacy `scanners:` config to lanes at load time and prints a one-line notice. To adopt the new schema, rewrite config-llm.yaml as a `lanes:` list (the skill offers this on upgrade)."
 
 config:
   # Required fields. The skill MUST resolve these from the user during setup.
@@ -53,44 +57,30 @@ config:
     - path: "paths.exclude"
       default: []
       note: "Glob list of paths excluded from LLM scanning."
-    - path: "scanners.codex"
-      default: false
-      note: "Enable OpenAI Codex SAST (uses local `codex` CLI subscription)."
-    - path: "scanners.claude"
-      default: false
-      note: "Enable Anthropic Claude SAST (uses local `claude` CLI on a Max/Pro subscription)."
-    - path: "scanners.gemma"
-      default: false
-      note: "Enable local Gemma SAST via Ollama."
-    - path: "codex"
+    - path: "lanes"
       default:
-        binary: "codex"
-        model: null
-        timeout: 1200
-      note: "Codex CLI tunables. Only used when scanners.codex is true."
-    - path: "claude"
-      default:
-        binary: "claude"
-        model: null
-        timeout: 1200
-      note: "Claude CLI tunables. Only used when scanners.claude is true. model null => the claude CLI default; set e.g. claude-sonnet-4-6 to pin."
-    - path: "gemma"
-      default:
-        base_url: "http://localhost:11434"
-        model: "gemma4:26b"
-        keep_alive: "5m"
-        timeout: 1800
-        max_files: 60
-        max_file_bytes: 12000
-        max_total_bytes: 200000
-      note: "Gemma SAST tunables. base_url MUST be loopback or RFC1918 — non-local URLs are refused at runtime."
+        - name: "codex"
+          backend: "codex-cli"
+          model: null
+          timeout: 1200
+          validate_timeout: 300
+        - name: "claude"
+          backend: "claude-cli"
+          model: "claude-sonnet-4-6"
+          timeout: 1200
+          validate_timeout: 300
+      note: >
+        List of LLM lanes. Each entry: name (scanner label / rule prefix),
+        backend (codex-cli | claude-cli | ollama), model (null => backend
+        default), timeout (primary scan), validate_timeout (per-finding
+        cross-validation). codex-cli/claude-cli accept an optional `binary`;
+        ollama lanes also take base_url (MUST be loopback/RFC1918), keep_alive,
+        max_files, max_file_bytes, max_total_bytes. At least one lane is
+        required; two enable cross-validation. Lane names must be unique.
     - path: "cross_validate"
       default:
         enabled: true
-        codex_timeout: 300
-        claude_timeout: 300
-        gemma_timeout: 180
-      note: "When at least two of scanners.codex/claude/gemma are true, each finding is reviewed by a different enabled lane. False positives downgrade severity one notch; critical never auto-downgrades; findings are never suppressed."
+      note: "When two or more lanes run, each finding is reviewed by a different lane. False positives downgrade severity one notch; critical never auto-downgrades; findings are never suppressed. Per-lane validation timeout is the lane's `validate_timeout`."
     - path: "triage"
       default:
         enabled: false
@@ -100,14 +90,26 @@ config:
         timeout: 600
         prewarm: true
         intro_timeout: 120
-      note: "Gemma-driven post-processing. Ollama URL/model inherit from `gemma:` when not set explicitly."
+      note: "Ollama-driven post-processing. Ollama URL/model inherit from the first `ollama` lane when not set explicitly."
     - path: "slack"
       default:
         enabled: false
       note: "Optional Slack digest of LLM-filed findings."
 
-  renamed_fields: []
-  removed_fields: []
+  renamed_fields:
+    - from: "cross_validate.codex_timeout / cross_validate.claude_timeout / cross_validate.gemma_timeout"
+      to: "lanes[].validate_timeout"
+      note: "Per-lane cross-validation timeout now lives on each lane. Auto-migrated from the legacy fields at load time."
+
+  removed_fields:
+    - path: "scanners"
+      note: "Replaced by the `lanes:` list. Auto-migrated at load time (scanners.codex -> codex-cli lane, scanners.claude -> claude-cli lane, scanners.gemma -> ollama lane)."
+    - path: "codex"
+      note: "Folded into a `lanes:` entry with backend codex-cli. Auto-migrated."
+    - path: "claude"
+      note: "Folded into a `lanes:` entry with backend claude-cli. Auto-migrated."
+    - path: "gemma"
+      note: "Folded into a `lanes:` entry with backend ollama. Auto-migrated."
 
 # Paths the consuming skill / orchestrator should know about.
 paths:

--- a/tools/security-scan-llm/pyproject.toml
+++ b/tools/security-scan-llm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "security-scan-llm"
-version = "0.2.0"
+version = "0.3.0"
 description = "Host-side LLM SAST lanes (codex + claude + gemma) for the leverj security-scan pipeline. Files findings into the same Projects v2 board as the deterministic Action."
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/security-scan-llm/security_scan_llm/__init__.py
+++ b/tools/security-scan-llm/security_scan_llm/__init__.py
@@ -5,4 +5,4 @@ substrates file into the same Projects v2 board; fingerprint scheme is shared so
 findings dedup across substrates.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/tools/security-scan-llm/security_scan_llm/cli.py
+++ b/tools/security-scan-llm/security_scan_llm/cli.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from security_scan_llm.config import Config, ConfigError, load_config
+from security_scan_llm.config import Config, ConfigError, LaneConfig, load_config
 from security_scan_llm.cross_validate import cross_validate
 from security_scan_llm.github import GitHub, GitHubError
 from security_scan_llm.models import Finding
@@ -54,14 +54,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 2
 
-    if not (cfg.scanners.codex or cfg.scanners.claude or cfg.scanners.gemma):
-        print(
-            "error: no LLM lane enabled — set at least one of "
-            "scanners.codex / scanners.claude / scanners.gemma in config-llm.yaml",
-            file=sys.stderr,
-        )
-        return 2
-
+    # load_config validates that at least one lane is configured (else ConfigError above).
     return run(cfg, repo_dir=args.repo_dir, dry_run=args.dry_run, work_dir=args.work_dir, keep_work=args.keep_work)
 
 
@@ -99,66 +92,20 @@ def run(
         completed: list[str] = []
         failed: list[tuple[str, str]] = []
 
-        if cfg.scanners.codex:
-            print("scan: codex", file=sys.stderr)
-            r = codex_runner.run(
-                target,
-                binary=cfg.codex.binary,
-                model=cfg.codex.model,
-                timeout=cfg.codex.timeout,
-            )
+        for lane in cfg.lanes:
+            print(f"scan: {lane.name} ({lane.backend})", file=sys.stderr)
+            r = _run_lane(lane, target, cfg.paths.exclude)
             _absorb(r, findings, completed, failed)
 
-        if cfg.scanners.claude:
-            print("scan: claude", file=sys.stderr)
-            r = claude_runner.run(
-                target,
-                binary=cfg.claude.binary,
-                model=cfg.claude.model,
-                timeout=cfg.claude.timeout,
-            )
-            _absorb(r, findings, completed, failed)
-
-        if cfg.scanners.gemma:
-            print("scan: gemma", file=sys.stderr)
-            r = gemma_runner.run(
-                target,
-                base_url=cfg.gemma.base_url,
-                model=cfg.gemma.model,
-                keep_alive=cfg.gemma.keep_alive,
-                timeout=cfg.gemma.timeout,
-                max_files=cfg.gemma.max_files,
-                max_file_bytes=cfg.gemma.max_file_bytes,
-                max_total_bytes=cfg.gemma.max_total_bytes,
-                exclude=cfg.paths.exclude,
-            )
-            _absorb(r, findings, completed, failed)
-
-        llm_lanes_done = [s for s in completed if s in ("codex", "claude", "gemma")]
-        if cfg.cross_validate.enabled and len(llm_lanes_done) >= 2:
-            before = sum(1 for f in findings if f.scanner in ("codex", "claude", "gemma"))
+        completed_lanes = [ln for ln in cfg.lanes if ln.name in completed]
+        if cfg.cross_validate.enabled and len(completed_lanes) >= 2:
+            before = sum(1 for f in findings if f.scanner in completed)
             print(
-                f"cross-validate: reviewing {before} LLM finding(s) across "
-                f"{', '.join(llm_lanes_done)}",
+                f"cross-validate: reviewing {before} finding(s) across "
+                f"{', '.join(ln.name for ln in completed_lanes)}",
                 file=sys.stderr,
             )
-            cross_validate(
-                findings,
-                repo_dir=target,
-                codex_enabled="codex" in llm_lanes_done,
-                claude_enabled="claude" in llm_lanes_done,
-                gemma_enabled="gemma" in llm_lanes_done,
-                codex_binary=cfg.codex.binary,
-                codex_model=cfg.codex.model,
-                codex_timeout=cfg.cross_validate.codex_timeout,
-                claude_binary=cfg.claude.binary,
-                claude_model=cfg.claude.model,
-                claude_timeout=cfg.cross_validate.claude_timeout,
-                ollama_url=cfg.gemma.base_url,
-                gemma_model=cfg.gemma.model,
-                gemma_keep_alive=cfg.gemma.keep_alive,
-                gemma_timeout=cfg.cross_validate.gemma_timeout,
-            )
+            cross_validate(findings, repo_dir=target, lanes=completed_lanes)
 
         triage = _maybe_triage(cfg)
 
@@ -202,6 +149,29 @@ def run(
             shutil.rmtree(target, ignore_errors=True)
             if work_dir is None and work_root.exists():
                 shutil.rmtree(work_root, ignore_errors=True)
+
+
+def _run_lane(lane: LaneConfig, target: Path, exclude: list[str]) -> RunnerResult:
+    """Dispatch a lane to its backend runner. Unknown backend fails soft."""
+    if lane.backend == "codex-cli":
+        return codex_runner.run(
+            target, scanner=lane.name, binary=lane.binary or "codex",
+            model=lane.model, timeout=lane.timeout,
+        )
+    if lane.backend == "claude-cli":
+        return claude_runner.run(
+            target, scanner=lane.name, binary=lane.binary or "claude",
+            model=lane.model, timeout=lane.timeout,
+        )
+    if lane.backend == "ollama":
+        return gemma_runner.run(
+            target, scanner=lane.name, base_url=lane.base_url,
+            model=lane.model or "gemma4:26b", keep_alive=lane.keep_alive,
+            timeout=lane.timeout, max_files=lane.max_files,
+            max_file_bytes=lane.max_file_bytes, max_total_bytes=lane.max_total_bytes,
+            exclude=exclude,
+        )
+    return RunnerResult(lane.name, None, False, f"unknown backend: {lane.backend}")
 
 
 def _absorb(r: RunnerResult, findings: list[Finding], completed: list[str], failed: list[tuple[str, str]]) -> None:

--- a/tools/security-scan-llm/security_scan_llm/config.py
+++ b/tools/security-scan-llm/security_scan_llm/config.py
@@ -3,60 +3,53 @@
 YAML on disk at `<repo>/.security-scan/config-llm.yaml`. Secrets via env
 (never on disk). Schema is intentionally NARROW — LLM-lane fields only. The
 deterministic container reads its own `<repo>/.security-scan/config.yaml`.
+
+Lanes are GENERIC: a `lanes:` list where each entry picks a `backend`
+(codex-cli / claude-cli / ollama) and a `model`. Any two lanes cross-validate
+each other. Legacy `scanners:` + `codex:`/`claude:`/`gemma:` configs are
+auto-migrated in `load_config` so old files keep working unchanged.
 """
 
 from __future__ import annotations
 
 import os
+import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
 
 from security_scan_llm.models import SEVERITY_ORDER
+from security_scan_llm.redact import is_local_url
 
 
 class ConfigError(ValueError):
     """Bad config — surfaced to the user with a clear message."""
 
 
-@dataclass
-class ScannersConfig:
-    """Which LLM lanes to run. Independent toggles.
-
-    Both default OFF — the host tool is "the LLM lane substrate." A user
-    invoking it with neither toggle on gets a clear error rather than a
-    silent no-op."""
-    codex: bool = False     # OpenAI Codex via local `codex` CLI (subscription)
-    claude: bool = False    # Anthropic Claude via local `claude` CLI (subscription)
-    gemma: bool = False     # Local Gemma via Ollama
+# Backends a lane can run on. Each maps to a runner in `runners/`.
+#   codex-cli  -> `codex` CLI (ChatGPT/Codex subscription, agentic, reads repo)
+#   claude-cli -> `claude` CLI (Claude Max/Pro subscription, agentic, reads repo)
+#   ollama     -> local Ollama (any model; file-batched prompt)
+BACKENDS = ("codex-cli", "claude-cli", "ollama")
+_AGENTIC_BACKENDS = ("codex-cli", "claude-cli")
+_DEFAULT_BINARY = {"codex-cli": "codex", "claude-cli": "claude"}
 
 
 @dataclass
-class CodexConfig:
-    """Tunables for the local Codex CLI runner. Auth is `codex login`
-    (ChatGPT subscription); the tool never sees an API key."""
-    binary: str = "codex"
-    model: str | None = None    # None => use codex's configured default
-    timeout: int = 1200         # seconds
-
-
-@dataclass
-class ClaudeConfig:
-    """Tunables for the local Claude CLI runner. Auth is `claude` OAuth login
-    (Max/Pro subscription); the tool never sees an API key."""
-    binary: str = "claude"
-    model: str | None = None    # None => use the claude CLI's configured default
-    timeout: int = 1200         # seconds
-
-
-@dataclass
-class GemmaConfig:
-    """Tunables for the Ollama-backed Gemma SAST runner."""
-    base_url: str = "http://localhost:11434"   # loopback by default; refused if non-local
-    model: str = "gemma4:26b"
+class LaneConfig:
+    """One LLM lane. `name` is the scanner id + rule-id prefix (so a lane named
+    `qwen` files findings as `qwen.*`). `backend` selects the runner."""
+    name: str
+    backend: str                         # one of BACKENDS
+    model: str | None = None             # None => the backend CLI's default
+    timeout: int = 1200                  # primary-scan timeout (seconds)
+    validate_timeout: int = 300          # per-finding cross-validation timeout
+    binary: str | None = None            # codex-cli / claude-cli only
+    # ollama-only knobs:
+    base_url: str = "http://localhost:11434"   # MUST be loopback or RFC1918
     keep_alive: str = "5m"
-    timeout: int = 1800
     max_files: int = 60
     max_file_bytes: int = 12_000
     max_total_bytes: int = 200_000
@@ -64,18 +57,16 @@ class GemmaConfig:
 
 @dataclass
 class CrossValidateConfig:
-    """Bidirectional review: each LLM lane's findings are reviewed by a different
-    enabled lane (e.g. codex<->claude, codex<->gemma). No effect unless at least
-    TWO of scanners.codex / scanners.claude / scanners.gemma are enabled."""
+    """Bidirectional review across lanes: each finding is reviewed by a
+    different enabled lane. No effect unless at least TWO lanes run. Per-lane
+    validation timeouts live on each LaneConfig (`validate_timeout`)."""
     enabled: bool = True
-    codex_timeout: int = 300
-    claude_timeout: int = 300
-    gemma_timeout: int = 180
 
 
 @dataclass
 class TriageConfig:
-    """Gemma-driven post-processing. All flags default off-ish to keep cost down."""
+    """Ollama-driven post-processing. All flags default off-ish to keep cost
+    down. Ollama URL/model default to the first `ollama` lane when not set."""
     enabled: bool = False
     base_url: str = "http://localhost:11434"
     model: str = "gemma4:26b"
@@ -114,13 +105,10 @@ class Config:
     ref: str
     project: ProjectConfig
     github_token: str   # resolved from env; never logged
-    scanners: ScannersConfig
+    lanes: list[LaneConfig]
     paths: PathsConfig
     severity_floor: str
     slack: SlackConfig
-    codex: CodexConfig = field(default_factory=CodexConfig)
-    claude: ClaudeConfig = field(default_factory=ClaudeConfig)
-    gemma: GemmaConfig = field(default_factory=GemmaConfig)
     cross_validate: CrossValidateConfig = field(default_factory=CrossValidateConfig)
     triage: TriageConfig = field(default_factory=TriageConfig)
 
@@ -175,57 +163,31 @@ def _from_dict(raw: dict) -> Config:
     if floor not in SEVERITY_ORDER:
         raise ConfigError(f"config: severity_floor must be one of {list(SEVERITY_ORDER)}, got {floor!r}")
 
-    scanners_raw = raw.get("scanners") or {}
-    scanners = ScannersConfig(
-        codex=bool(scanners_raw.get("codex", False)),
-        claude=bool(scanners_raw.get("claude", False)),
-        gemma=bool(scanners_raw.get("gemma", False)),
-    )
-
-    codex_raw = raw.get("codex") or {}
-    codex_cfg = CodexConfig(
-        binary=str(codex_raw.get("binary") or "codex"),
-        model=(str(codex_raw.get("model")) if codex_raw.get("model") else None),
-        timeout=int(codex_raw.get("timeout") or 1200),
-    )
-
-    claude_raw = raw.get("claude") or {}
-    claude_cfg = ClaudeConfig(
-        binary=str(claude_raw.get("binary") or "claude"),
-        model=(str(claude_raw.get("model")) if claude_raw.get("model") else None),
-        timeout=int(claude_raw.get("timeout") or 1200),
-    )
-
-    gemma_raw = raw.get("gemma") or {}
-    gemma_cfg = GemmaConfig(
-        base_url=str(gemma_raw.get("base_url") or "http://localhost:11434"),
-        model=str(gemma_raw.get("model") or "gemma4:26b"),
-        keep_alive=str(gemma_raw.get("keep_alive") or "5m"),
-        timeout=int(gemma_raw.get("timeout") or 1800),
-        max_files=int(gemma_raw.get("max_files") or 60),
-        max_file_bytes=int(gemma_raw.get("max_file_bytes") or 12_000),
-        max_total_bytes=int(gemma_raw.get("max_total_bytes") or 200_000),
-    )
+    # Lanes: new `lanes:` list, or auto-migrated from the legacy schema.
+    if raw.get("lanes"):
+        lanes = [_parse_lane(item, i) for i, item in enumerate(raw["lanes"])]
+    else:
+        lanes = _migrate_legacy_lanes(raw)
+    _validate_lanes(lanes)
 
     cv_raw = raw.get("cross_validate") or {}
-    cv_cfg = CrossValidateConfig(
-        enabled=bool(cv_raw.get("enabled", True)),
-        codex_timeout=int(cv_raw.get("codex_timeout") or 300),
-        claude_timeout=int(cv_raw.get("claude_timeout") or 300),
-        gemma_timeout=int(cv_raw.get("gemma_timeout") or 180),
-    )
+    cv_cfg = CrossValidateConfig(enabled=bool(cv_raw.get("enabled", True)))
 
     paths_raw = raw.get("paths") or {}
     paths = PathsConfig(exclude=list(paths_raw.get("exclude") or []))
 
+    # Triage Ollama defaults inherit from the first `ollama` lane so the user
+    # configures Ollama once. Explicit `triage.<field>` still wins.
+    first_ollama = next((ln for ln in lanes if ln.backend == "ollama"), None)
+    ol_url = first_ollama.base_url if first_ollama else "http://localhost:11434"
+    ol_model = first_ollama.model if (first_ollama and first_ollama.model) else "gemma4:26b"
+    ol_keep = first_ollama.keep_alive if first_ollama else "5m"
     triage_raw = raw.get("triage") or {}
-    # Triage Ollama defaults inherit from `gemma:` so the user configures
-    # Ollama once. Explicit `triage.<field>` still wins.
     triage_cfg = TriageConfig(
         enabled=bool(triage_raw.get("enabled", False)),
-        base_url=str(triage_raw.get("base_url") or gemma_cfg.base_url),
-        model=str(triage_raw.get("model") or gemma_cfg.model),
-        keep_alive=str(triage_raw.get("keep_alive") or gemma_cfg.keep_alive),
+        base_url=str(triage_raw.get("base_url") or ol_url),
+        model=str(triage_raw.get("model") or ol_model),
+        keep_alive=str(triage_raw.get("keep_alive") or ol_keep),
         timeout=int(triage_raw.get("timeout") or 600),
         prewarm=bool(triage_raw.get("prewarm", True)),
         intro_timeout=int(triage_raw.get("intro_timeout") or 120),
@@ -247,13 +209,115 @@ def _from_dict(raw: dict) -> Config:
         ref=ref,
         project=project,
         github_token=token,
-        scanners=scanners,
+        lanes=lanes,
         paths=paths,
         severity_floor=floor,
         slack=slack,
-        codex=codex_cfg,
-        claude=claude_cfg,
-        gemma=gemma_cfg,
         cross_validate=cv_cfg,
         triage=triage_cfg,
     )
+
+
+def _parse_lane(item: dict, idx: int) -> LaneConfig:
+    if not isinstance(item, dict):
+        raise ConfigError(f"config: lanes[{idx}] must be a mapping")
+    name = str(_require(item, "name", f"lanes[{idx}]"))
+    backend = str(_require(item, "backend", f"lanes[{idx}]"))
+    if backend not in BACKENDS:
+        raise ConfigError(
+            f"config: lanes[{idx}].backend must be one of {list(BACKENDS)}, got {backend!r}"
+        )
+    binary = item.get("binary") or (_DEFAULT_BINARY.get(backend))
+    return LaneConfig(
+        name=name,
+        backend=backend,
+        model=(str(item["model"]) if item.get("model") else None),
+        timeout=int(item.get("timeout") or 1200),
+        validate_timeout=int(item.get("validate_timeout") or 300),
+        binary=binary,
+        base_url=str(item.get("base_url") or "http://localhost:11434"),
+        keep_alive=str(item.get("keep_alive") or "5m"),
+        max_files=int(item.get("max_files") or 60),
+        max_file_bytes=int(item.get("max_file_bytes") or 12_000),
+        max_total_bytes=int(item.get("max_total_bytes") or 200_000),
+    )
+
+
+def _validate_lanes(lanes: list[LaneConfig]) -> None:
+    if not lanes:
+        raise ConfigError(
+            "config: no lanes enabled — add at least one entry under `lanes:` "
+            "(or set a legacy scanners.* toggle). Two lanes are needed for cross-validation."
+        )
+    seen: set[str] = set()
+    for ln in lanes:
+        # name becomes the SARIF driver name + rule-id prefix + issue-title text;
+        # keep it to a safe kebab/alnum set so it can't malform downstream output.
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", ln.name):
+            raise ConfigError(
+                f"config: lane name {ln.name!r} must match [A-Za-z0-9_-]+ (short kebab-case)"
+            )
+        if ln.name in seen:
+            raise ConfigError(f"config: duplicate lane name {ln.name!r} — names must be unique")
+        seen.add(ln.name)
+        # binary must be a bare command resolved on PATH, never a path to an
+        # arbitrary on-disk executable.
+        if ln.binary and os.path.basename(ln.binary) != ln.binary:
+            raise ConfigError(
+                f"config: lane {ln.name!r} binary {ln.binary!r} must be a bare command name, not a path"
+            )
+        if ln.backend == "ollama" and not is_local_url(ln.base_url):
+            raise ConfigError(
+                f"config: lane {ln.name!r} base_url {ln.base_url!r} is not loopback/RFC1918 — "
+                "source content must not cross a public boundary to a remote Ollama"
+            )
+
+
+def _migrate_legacy_lanes(raw: dict) -> list[LaneConfig]:
+    """Synthesize a `lanes:` list from the legacy schema (scanners.* toggles +
+    codex:/claude:/gemma: blocks + cross_validate.<lane>_timeout). Keeps old
+    config files working without an edit."""
+    scanners = raw.get("scanners") or {}
+    cv = raw.get("cross_validate") or {}
+    lanes: list[LaneConfig] = []
+
+    if scanners.get("codex"):
+        c = raw.get("codex") or {}
+        lanes.append(LaneConfig(
+            name="codex", backend="codex-cli",
+            model=(str(c["model"]) if c.get("model") else None),
+            timeout=int(c.get("timeout") or 1200),
+            validate_timeout=int(cv.get("codex_timeout") or 300),
+            binary=str(c.get("binary") or "codex"),
+        ))
+    if scanners.get("claude"):
+        c = raw.get("claude") or {}
+        lanes.append(LaneConfig(
+            name="claude", backend="claude-cli",
+            model=(str(c["model"]) if c.get("model") else None),
+            timeout=int(c.get("timeout") or 1200),
+            validate_timeout=int(cv.get("claude_timeout") or 300),
+            binary=str(c.get("binary") or "claude"),
+        ))
+    if scanners.get("gemma"):
+        g = raw.get("gemma") or {}
+        lanes.append(LaneConfig(
+            name="gemma", backend="ollama",
+            model=str(g.get("model") or "gemma4:26b"),
+            timeout=int(g.get("timeout") or 1800),
+            validate_timeout=int(cv.get("gemma_timeout") or 180),
+            base_url=str(g.get("base_url") or "http://localhost:11434"),
+            keep_alive=str(g.get("keep_alive") or "5m"),
+            max_files=int(g.get("max_files") or 60),
+            max_file_bytes=int(g.get("max_file_bytes") or 12_000),
+            max_total_bytes=int(g.get("max_total_bytes") or 200_000),
+        ))
+
+    if lanes:
+        print(
+            "config: migrated legacy `scanners:` config to "
+            f"{len(lanes)} lane(s) ({', '.join(ln.name for ln in lanes)}). "
+            "Consider rewriting config-llm.yaml to the `lanes:` list — see the manifest.",
+            file=sys.stderr,
+        )
+    return lanes

--- a/tools/security-scan-llm/security_scan_llm/config.py
+++ b/tools/security-scan-llm/security_scan_llm/config.py
@@ -195,6 +195,13 @@ def _from_dict(raw: dict) -> Config:
         prose_enabled=bool(triage_raw.get("prose_enabled", False)),
         fuzzy_dup_enabled=bool(triage_raw.get("fuzzy_dup_enabled", False)),
     )
+    # Same loopback policy as ollama lanes: triage must not send snippets to a
+    # remote Ollama. Enforced at load time when triage is on (not just runtime).
+    if triage_cfg.enabled and not is_local_url(triage_cfg.base_url):
+        raise ConfigError(
+            f"config: triage.base_url {triage_cfg.base_url!r} is not loopback/RFC1918 — "
+            "triage must not send content to a remote Ollama"
+        )
 
     slack_raw = raw.get("slack") or {}
     slack = SlackConfig(

--- a/tools/security-scan-llm/security_scan_llm/cross_validate.py
+++ b/tools/security-scan-llm/security_scan_llm/cross_validate.py
@@ -41,6 +41,7 @@ from pathlib import Path
 
 import requests
 
+from security_scan_llm.config import LaneConfig
 from security_scan_llm.models import SEVERITY_ORDER, Finding
 from security_scan_llm.redact import is_local_url, redact_text
 
@@ -94,63 +95,52 @@ def cross_validate(
     findings: list[Finding],
     *,
     repo_dir: Path,
-    codex_enabled: bool = False,
-    claude_enabled: bool = False,
-    gemma_enabled: bool = False,
-    codex_binary: str = "codex",
-    codex_model: str | None = None,
-    codex_timeout: int = 300,
-    claude_binary: str = "claude",
-    claude_model: str | None = None,
-    claude_timeout: int = 300,
-    ollama_url: str = "http://host.docker.internal:11434",
-    gemma_model: str = "gemma4:26b",
-    gemma_keep_alive: str = "5m",
-    gemma_timeout: int = 180,
+    lanes: list[LaneConfig],
 ) -> list[Finding]:
     """Mutate `findings` in place with a `cross_validation` extra and possibly
     a downgraded severity. Returns the same list for convenience.
 
-    Needs at least two reachable validators — with one lane there is nothing to
-    compare against. A finding is validated by the first available lane whose
-    name differs from its own scanner. Lanes that are enabled but unreachable
-    at validation time are silently dropped from the registry.
+    Needs at least two reachable validator lanes — with one lane there is
+    nothing to compare against. Each finding is validated by the first lane (in
+    `lanes` order) whose name differs from its own scanner. Lanes that are
+    unreachable at validation time (missing CLI, Ollama down) are silently
+    dropped from the registry.
     """
-    # Registry of reachable validators: scanner-name -> fn(finding)->(verdict,reason).
+    # Registry of reachable validators: lane-name -> fn(finding)->(verdict,reason).
+    # `L=lane` default-binds each lane into its lambda (avoids loop late-binding).
     validators = {}
-
-    if codex_enabled and shutil.which(codex_binary) is not None:
-        validators["codex"] = lambda f: _codex_verdict(
-            f, repo_dir=repo_dir, binary=codex_binary,
-            model=codex_model, timeout=codex_timeout,
-        )
-    if claude_enabled and shutil.which(claude_binary) is not None:
-        validators["claude"] = lambda f: _claude_verdict(
-            f, repo_dir=repo_dir, binary=claude_binary,
-            model=claude_model, timeout=claude_timeout,
-        )
-    if gemma_enabled:
-        # Defence-in-depth: even though redact_text scrubs known-token shapes
-        # from snippets, refuse the Gemma direction if base_url isn't local.
-        # Cross-validation pays out at the margin; a remote round-trip of
-        # source does not.
-        if not is_local_url(ollama_url):
-            print(
-                f"cross-validate: gemma validator skipped — ollama_url {ollama_url!r} "
-                "is not loopback/private",
-                file=sys.stderr,
+    for lane in lanes:
+        if lane.backend == "codex-cli" and shutil.which(lane.binary or "codex") is not None:
+            validators[lane.name] = lambda f, L=lane: _codex_verdict(
+                f, repo_dir=repo_dir, binary=L.binary or "codex",
+                model=L.model, timeout=L.validate_timeout,
             )
-        elif _ping_ollama(ollama_url):
-            validators["gemma"] = lambda f: _gemma_verdict(
-                f, repo_dir=repo_dir, url=ollama_url, model=gemma_model,
-                keep_alive=gemma_keep_alive, timeout=gemma_timeout,
+        elif lane.backend == "claude-cli" and shutil.which(lane.binary or "claude") is not None:
+            validators[lane.name] = lambda f, L=lane: _claude_verdict(
+                f, repo_dir=repo_dir, binary=L.binary or "claude",
+                model=L.model, timeout=L.validate_timeout,
             )
+        elif lane.backend == "ollama":
+            # Defence-in-depth: refuse the Ollama direction if base_url isn't
+            # local, even though snippets are redacted. Cross-validation pays
+            # out at the margin; a remote round-trip of source does not.
+            if not is_local_url(lane.base_url):
+                print(
+                    f"cross-validate: lane {lane.name!r} skipped — base_url "
+                    f"{lane.base_url!r} is not loopback/private",
+                    file=sys.stderr,
+                )
+            elif _ping_ollama(lane.base_url):
+                validators[lane.name] = lambda f, L=lane: _gemma_verdict(
+                    f, repo_dir=repo_dir, url=L.base_url, model=L.model or "gemma4:26b",
+                    keep_alive=L.keep_alive, timeout=L.validate_timeout,
+                )
 
     if len(validators) < 2:
         return findings
 
-    # Deterministic preference when more than one other lane could validate.
-    order = [name for name in ("codex", "claude", "gemma") if name in validators]
+    # Deterministic preference (lanes order) when more than one lane could validate.
+    order = [lane.name for lane in lanes if lane.name in validators]
     for f in findings:
         validator = next((name for name in order if name != f.scanner), None)
         if validator is None:

--- a/tools/security-scan-llm/security_scan_llm/cross_validate.py
+++ b/tools/security-scan-llm/security_scan_llm/cross_validate.py
@@ -32,7 +32,6 @@ user's subscription rather than a metered API.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -44,6 +43,7 @@ import requests
 from security_scan_llm.config import LaneConfig
 from security_scan_llm.models import SEVERITY_ORDER, Finding
 from security_scan_llm.redact import is_local_url, redact_text
+from security_scan_llm.runners import agent_env
 
 # Severity downgrade ladder. Critical is intentionally NOT downgraded — the
 # asymmetry is deliberate (worst case for FP-on-critical is one extra issue
@@ -242,7 +242,7 @@ def _codex_verdict(
         try:
             r = subprocess.run(
                 cmd, cwd=str(repo_dir), capture_output=True, text=True,
-                timeout=timeout, check=False, env={**os.environ},
+                timeout=timeout, check=False, env=agent_env(),
             )
         except subprocess.TimeoutExpired:
             return ("uncertain", "validator timeout")
@@ -285,7 +285,7 @@ def _claude_verdict(
     try:
         r = subprocess.run(
             cmd, cwd=str(repo_dir), input=prompt, capture_output=True, text=True,
-            timeout=timeout, check=False, env={**os.environ},
+            timeout=timeout, check=False, env=agent_env(),
         )
     except subprocess.TimeoutExpired:
         return ("uncertain", "validator timeout")

--- a/tools/security-scan-llm/security_scan_llm/normalize.py
+++ b/tools/security-scan-llm/security_scan_llm/normalize.py
@@ -42,9 +42,9 @@ def normalize_sarif(sarif: dict, scanner: str, exclude: list[str] | None = None)
     if scanner == "syft":
         return []
 
-    if scanner not in _CATEGORY:
-        raise ValueError(f"unknown scanner: {scanner!r}")
-    category = _CATEGORY[scanner]
+    # Custom LLM lane names (any `lanes:` entry) default to the SAST category;
+    # the fixed deterministic scanners keep their specific category.
+    category = _CATEGORY.get(scanner, "sast")
 
     findings: list[Finding] = []
     for run in sarif.get("runs") or []:

--- a/tools/security-scan-llm/security_scan_llm/runners/__init__.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/__init__.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+# Env vars an agentic CLI subprocess (codex / claude) has no business seeing.
+# The CLIs' own auth (CODEX_HOME, ~/.claude.json, PATH, HOME, …) is preserved;
+# only secrets the read-only audit agent never needs are stripped.
+_STRIP_FROM_AGENT_ENV = (
+    # GitHub PAT — used only by the filer, never by the audit agent.
+    "GITHUB_TOKEN", "GH_TOKEN",
+    # Force subscription auth for the LLM CLIs: an API key in env would route to
+    # a metered API, which this tool deliberately avoids.
+    "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY",
+    # Unrelated creds that may sit in the shell / CI env — no audit use for any.
+    "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+    "NPM_TOKEN", "DOCKER_PASSWORD",
+    "SLACK_BOT_TOKEN", "SLACK_WEBHOOK_URL",
+    "SUPABASE_DB_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_ANON_KEY",
+)
+
+
+def agent_env() -> dict[str, str]:
+    """Process environment minus secrets the audit agent doesn't need."""
+    return {k: v for k, v in os.environ.items() if k not in _STRIP_FROM_AGENT_ENV}
 
 
 @dataclass
@@ -16,7 +38,8 @@ class RunnerResult:
 
 
 def _run(cmd: list[str], cwd: Path, timeout: int = 600) -> tuple[int, str, str]:
-    """Wrap subprocess.run. Returns (returncode, stdout, stderr). Never logs args."""
+    """Wrap subprocess.run. Returns (returncode, stdout, stderr). Never logs args.
+    Uses agent_env() so a caller can't accidentally leak the PAT to a child."""
     proc = subprocess.run(
         cmd,
         cwd=str(cwd),
@@ -24,5 +47,6 @@ def _run(cmd: list[str], cwd: Path, timeout: int = 600) -> tuple[int, str, str]:
         text=True,
         timeout=timeout,
         check=False,
+        env=agent_env(),
     )
     return proc.returncode, proc.stdout, proc.stderr

--- a/tools/security-scan-llm/security_scan_llm/runners/claude.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/claude.py
@@ -15,12 +15,13 @@ existing normalize.py pipeline consumes it like any other scanner.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 from pathlib import Path
 
-from . import RunnerResult
+from security_scan_llm.redact import redact_text
+
+from . import RunnerResult, agent_env
 from .codex import _PROMPT, _SCHEMA, _to_sarif
 
 # Read-only toolset the agent is allowed to use during the audit. No Bash/Edit/
@@ -72,7 +73,7 @@ def run(
             text=True,
             timeout=timeout,
             check=False,
-            env={**os.environ},
+            env=agent_env(),
         )
     except subprocess.TimeoutExpired:
         return RunnerResult(scanner, None, False, f"timeout after {timeout}s")
@@ -82,7 +83,7 @@ def run(
         return RunnerResult(scanner, None, False, f"{type(e).__name__}: {e}")
 
     if r.returncode != 0:
-        err = (r.stderr or r.stdout or "").strip()
+        err = redact_text((r.stderr or r.stdout or "").strip())
         return RunnerResult(scanner, None, False, f"exit {r.returncode}: {err[:300]}")
 
     try:

--- a/tools/security-scan-llm/security_scan_llm/runners/claude.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/claude.py
@@ -30,12 +30,16 @@ _ALLOWED_TOOLS = ("Read", "Grep", "Glob")
 
 def run(
     repo_dir: Path,
+    scanner: str = "claude",
     binary: str = "claude",
     model: str | None = None,
     timeout: int = 1200,
     extra_args: list[str] | None = None,
 ) -> RunnerResult:
     """Invoke claude on `repo_dir` and return its findings as a SARIF doc.
+
+    `scanner` is the lane name — it labels the RunnerResult and namespaces
+    rule ids (so a lane named `audit` files `audit.*`).
 
     Failure modes (all return completed=False with a clear error string):
       - binary missing on PATH
@@ -44,7 +48,7 @@ def run(
       - schema enforcement fails (no `findings` key)
     """
     if shutil.which(binary) is None:
-        return RunnerResult("claude", None, False, f"binary not found: {binary}")
+        return RunnerResult(scanner, None, False, f"binary not found: {binary}")
 
     cmd = [
         binary, "-p",
@@ -71,24 +75,24 @@ def run(
             env={**os.environ},
         )
     except subprocess.TimeoutExpired:
-        return RunnerResult("claude", None, False, f"timeout after {timeout}s")
+        return RunnerResult(scanner, None, False, f"timeout after {timeout}s")
     except FileNotFoundError:
-        return RunnerResult("claude", None, False, f"binary not found: {binary}")
+        return RunnerResult(scanner, None, False, f"binary not found: {binary}")
     except Exception as e:
-        return RunnerResult("claude", None, False, f"{type(e).__name__}: {e}")
+        return RunnerResult(scanner, None, False, f"{type(e).__name__}: {e}")
 
     if r.returncode != 0:
         err = (r.stderr or r.stdout or "").strip()
-        return RunnerResult("claude", None, False, f"exit {r.returncode}: {err[:300]}")
+        return RunnerResult(scanner, None, False, f"exit {r.returncode}: {err[:300]}")
 
     try:
         envelope = json.loads(r.stdout or "{}")
     except json.JSONDecodeError as e:
-        return RunnerResult("claude", None, False, f"output parse error: {e}")
+        return RunnerResult(scanner, None, False, f"output parse error: {e}")
 
     if envelope.get("is_error"):
         return RunnerResult(
-            "claude", None, False,
+            scanner, None, False,
             f"claude reported error: {str(envelope.get('result'))[:200]}",
         )
 
@@ -97,13 +101,13 @@ def run(
         denials = envelope.get("permission_denials") or []
         if denials:
             return RunnerResult(
-                "claude", None, False,
+                scanner, None, False,
                 f"claude blocked by tool-permission denials: {denials[:3]}",
             )
-        return RunnerResult("claude", None, False, "claude produced no structured_output")
+        return RunnerResult(scanner, None, False, "claude produced no structured_output")
 
     findings = structured.get("findings") or []
     if not isinstance(findings, list):
-        return RunnerResult("claude", None, False, "output schema mismatch: 'findings' not a list")
+        return RunnerResult(scanner, None, False, "output schema mismatch: 'findings' not a list")
 
-    return RunnerResult("claude", _to_sarif(findings, "claude"), True, None)
+    return RunnerResult(scanner, _to_sarif(findings, scanner), True, None)

--- a/tools/security-scan-llm/security_scan_llm/runners/codex.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/codex.py
@@ -113,12 +113,16 @@ Return ONLY the JSON object matching the supplied schema. No prose, no preamble.
 
 def run(
     repo_dir: Path,
+    scanner: str = "codex",
     binary: str = "codex",
     model: str | None = None,
     timeout: int = 1200,
     extra_args: list[str] | None = None,
 ) -> RunnerResult:
     """Invoke codex on `repo_dir` and return its findings as a SARIF doc.
+
+    `scanner` is the lane name — it labels the RunnerResult and namespaces
+    rule ids (so a lane named `audit` files `audit.*`).
 
     Failure modes (all return completed=False with a clear error string):
       - binary missing on PATH
@@ -131,7 +135,7 @@ def run(
     modify the cloned repo, and `--ephemeral` so no session metadata persists.
     """
     if shutil.which(binary) is None:
-        return RunnerResult("codex", None, False, f"binary not found: {binary}")
+        return RunnerResult(scanner, None, False, f"binary not found: {binary}")
 
     with tempfile.TemporaryDirectory(prefix="codex-security_scan-") as td:
         schema_path = Path(td) / "schema.json"
@@ -168,21 +172,21 @@ def run(
                 env={**os.environ},
             )
         except subprocess.TimeoutExpired:
-            return RunnerResult("codex", None, False, f"timeout after {timeout}s")
+            return RunnerResult(scanner, None, False, f"timeout after {timeout}s")
         except FileNotFoundError:
-            return RunnerResult("codex", None, False, f"binary not found: {binary}")
+            return RunnerResult(scanner, None, False, f"binary not found: {binary}")
         except Exception as e:
-            return RunnerResult("codex", None, False, f"{type(e).__name__}: {e}")
+            return RunnerResult(scanner, None, False, f"{type(e).__name__}: {e}")
 
         if r.returncode != 0:
             err = (r.stderr or r.stdout or "").strip()
             # Detect auth failure (most common user-actionable error) and surface clearly.
             if "not logged in" in err.lower() or "auth" in err.lower():
                 return RunnerResult(
-                    "codex", None, False,
+                    scanner, None, False,
                     "codex auth failed — run `codex login` first",
                 )
-            return RunnerResult("codex", None, False, f"exit {r.returncode}: {err[:300]}")
+            return RunnerResult(scanner, None, False, f"exit {r.returncode}: {err[:300]}")
 
         if not output_path.is_file():
             return RunnerResult(
@@ -193,14 +197,14 @@ def run(
         try:
             data = json.loads(output_path.read_text() or "{}")
         except json.JSONDecodeError as e:
-            return RunnerResult("codex", None, False, f"output parse error: {e}")
+            return RunnerResult(scanner, None, False, f"output parse error: {e}")
 
     findings = data.get("findings") or []
     if not isinstance(findings, list):
-        return RunnerResult("codex", None, False, "output schema mismatch: 'findings' not a list")
+        return RunnerResult(scanner, None, False, "output schema mismatch: 'findings' not a list")
 
-    sarif = _to_sarif(findings)
-    return RunnerResult("codex", sarif, True, None)
+    sarif = _to_sarif(findings, scanner)
+    return RunnerResult(scanner, sarif, True, None)
 
 
 def _to_sarif(findings: list[dict], scanner: str = "codex") -> dict:

--- a/tools/security-scan-llm/security_scan_llm/runners/codex.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/codex.py
@@ -12,13 +12,14 @@ pipeline can consume it like any other scanner.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
-from . import RunnerResult
+from security_scan_llm.redact import redact_text
+
+from . import RunnerResult, agent_env
 
 # Map our severity vocabulary to a numeric security-severity used by the SARIF
 # normalizer (it expects CVSS-style numerics under properties.security-severity).
@@ -166,10 +167,9 @@ def run(
                 text=True,
                 timeout=timeout,
                 check=False,
-                # Don't inherit security_scan's env wholesale — keep CODEX_HOME etc., but
-                # strip anything that might confuse the agent. Codex reads its own
-                # config from ~/.codex/.
-                env={**os.environ},
+                # Strip the GitHub PAT from the agent's env (it only needs its own
+                # ~/.codex auth). Codex reads its config from ~/.codex/.
+                env=agent_env(),
             )
         except subprocess.TimeoutExpired:
             return RunnerResult(scanner, None, False, f"timeout after {timeout}s")
@@ -179,7 +179,7 @@ def run(
             return RunnerResult(scanner, None, False, f"{type(e).__name__}: {e}")
 
         if r.returncode != 0:
-            err = (r.stderr or r.stdout or "").strip()
+            err = redact_text((r.stderr or r.stdout or "").strip())
             # Detect auth failure (most common user-actionable error) and surface clearly.
             if "not logged in" in err.lower() or "auth" in err.lower():
                 return RunnerResult(

--- a/tools/security-scan-llm/security_scan_llm/runners/gemma.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/gemma.py
@@ -91,6 +91,7 @@ _SYSTEM_PROMPT = (
 
 def run(
     repo_dir: Path,
+    scanner: str = "gemma",
     base_url: str = "http://host.docker.internal:11434",
     model: str = "gemma4:26b",
     keep_alive: str = "5m",
@@ -100,15 +101,17 @@ def run(
     max_total_bytes: int = 200_000,
     exclude: list[str] | None = None,
 ) -> RunnerResult:
-    """Walk `repo_dir`, batch source files into a single Gemma prompt, parse the JSON.
+    """Walk `repo_dir`, batch source files into one Ollama prompt, parse the JSON.
+
+    `scanner` is the lane name — it labels the RunnerResult and namespaces rule
+    ids. The backend is any Ollama model (not just gemma); `model` picks it.
 
     Returns a SARIF dict on success; on any HTTP/parse failure returns completed=False
     with a short error string. Like every other runner, partial failure contributes
     zero findings — never blanket "all clear".
     """
     if not is_local_url(base_url):
-        return RunnerResult(
-            "gemma", None, False,
+        return RunnerResult(scanner, None, False,
             f"refusing to send source to non-local Ollama at {base_url!r}; "
             "set gemma.base_url to a loopback/private host",
         )
@@ -116,7 +119,7 @@ def run(
     files = _select_files(repo_dir, exclude or [], max_files, max_file_bytes, max_total_bytes)
     if not files:
         # Empty repo or all files filtered out — treat as a no-op success.
-        return RunnerResult("gemma", _empty_sarif(), True, None)
+        return RunnerResult(scanner, _empty_sarif(), True, None)
 
     user_content = _build_user_prompt(files, repo_dir)
 
@@ -136,24 +139,24 @@ def run(
             timeout=timeout,
         )
     except requests.RequestException as e:
-        return RunnerResult("gemma", None, False, f"ollama unreachable: {e}")
+        return RunnerResult(scanner, None, False, f"ollama unreachable: {e}")
 
     if r.status_code >= 400:
-        return RunnerResult("gemma", None, False, f"ollama http {r.status_code}: {r.text[:200]}")
+        return RunnerResult(scanner, None, False, f"ollama http {r.status_code}: {r.text[:200]}")
 
     try:
         body = r.json() or {}
         content = (body.get("message") or {}).get("content") or ""
         data = json.loads(content) if content else {}
     except (ValueError, json.JSONDecodeError) as e:
-        return RunnerResult("gemma", None, False, f"parse error: {e}")
+        return RunnerResult(scanner, None, False, f"parse error: {e}")
 
     raw_findings = data.get("findings") if isinstance(data, dict) else None
     if not isinstance(raw_findings, list):
-        return RunnerResult("gemma", None, False, "output schema mismatch: 'findings' not a list")
+        return RunnerResult(scanner, None, False, "output schema mismatch: 'findings' not a list")
 
-    sarif = _to_sarif(raw_findings)
-    return RunnerResult("gemma", sarif, True, None)
+    sarif = _to_sarif(raw_findings, scanner)
+    return RunnerResult(scanner, sarif, True, None)
 
 
 def _select_files(
@@ -266,7 +269,7 @@ def _empty_sarif() -> dict:
     }
 
 
-def _to_sarif(findings: list[dict]) -> dict:
+def _to_sarif(findings: list[dict], scanner: str = "gemma") -> dict:
     rules: list[dict] = []
     results: list[dict] = []
     seen: dict[str, dict] = {}
@@ -277,8 +280,8 @@ def _to_sarif(findings: list[dict]) -> dict:
         sev = str(f.get("severity") or "medium").lower()
         if sev not in _SEVERITY_TO_NUMERIC:
             sev = "medium"
-        rid_raw = str(f.get("rule_id") or "gemma-finding").strip()
-        rid = rid_raw if rid_raw.startswith("gemma.") else f"gemma.{rid_raw}"
+        rid_raw = str(f.get("rule_id") or f"{scanner}-finding").strip()
+        rid = rid_raw if rid_raw.startswith(f"{scanner}.") else f"{scanner}.{rid_raw}"
         title = str(f.get("title") or rid).strip()
         message = str(f.get("message") or "").strip()
         file_path = str(f.get("file") or "").strip()
@@ -297,7 +300,7 @@ def _to_sarif(findings: list[dict]) -> dict:
                 "name": title,
                 "properties": {
                     "security-severity": _SEVERITY_TO_NUMERIC[sev],
-                    "scanner": "gemma",
+                    "scanner": scanner,
                 },
             }
             seen[rid] = entry
@@ -310,7 +313,7 @@ def _to_sarif(findings: list[dict]) -> dict:
             "properties": {
                 "title": title,
                 "security-severity": _SEVERITY_TO_NUMERIC[sev],
-                "scanner": "gemma",
+                "scanner": scanner,
             },
             "locations": [{
                 "physicalLocation": {
@@ -326,7 +329,7 @@ def _to_sarif(findings: list[dict]) -> dict:
     return {
         "version": "2.1.0",
         "runs": [{
-            "tool": {"driver": {"name": "gemma", "rules": rules}},
+            "tool": {"driver": {"name": scanner, "rules": rules}},
             "results": results,
         }],
     }

--- a/tools/security-scan-llm/security_scan_llm/runners/gemma.py
+++ b/tools/security-scan-llm/security_scan_llm/runners/gemma.py
@@ -142,7 +142,7 @@ def run(
         return RunnerResult(scanner, None, False, f"ollama unreachable: {e}")
 
     if r.status_code >= 400:
-        return RunnerResult(scanner, None, False, f"ollama http {r.status_code}: {r.text[:200]}")
+        return RunnerResult(scanner, None, False, f"ollama http {r.status_code}: {redact_text(r.text[:200])}")
 
     try:
         body = r.json() or {}


### PR DESCRIPTION
Makes the LLM SAST tool **provider-generic**: instead of three fixed lanes (codex/claude/gemma toggles), the config is a `lanes:` list where each lane picks a `backend` and `model`. Any two lanes cross-reference each other; any Ollama model is a first-class, properly-labeled lane; N lanes are allowed.

> Stacked on #31 → #30. Base is `feat/claude-lane`; retarget to `master` as the stack merges. Schema v2, tool v0.3.0.

## New config shape
```yaml
lanes:
  - {name: codex,  backend: codex-cli,  model: null}
  - {name: claude, backend: claude-cli, model: claude-sonnet-4-6}
  - {name: qwen,   backend: ollama,     model: qwen2.5-coder:32b, base_url: http://localhost:11434}
cross_validate: {enabled: true}
```
- `name` → scanner label + rule-id prefix (a lane named `qwen` files `qwen.*`).
- `backend` → `codex-cli` | `claude-cli` | `ollama`.
- Per-lane `timeout` (scan) and `validate_timeout` (cross-validation).

## Changes
- **config.py** — `LaneConfig`; `load_config` parses `lanes:` or **auto-migrates** a legacy `scanners:`/`codex:`/`claude:`/`gemma:` config at load time (one-line stderr notice, no edit needed). `_validate_lanes` enforces unique kebab-case names, bare-command binaries, and loopback/RFC1918 `base_url` for ollama lanes.
- **cli.py** — `_run_lane()` dispatches by backend; scan loop iterates `cfg.lanes`; cross-validate gets the completed lanes.
- **runners/{codex,claude,gemma}.py** — each `run()` takes a `scanner` (lane name) that labels the result and namespaces rule ids; `_to_sarif` parameterized.
- **cross_validate.py** — validator registry built from the lanes list (each lambda default-binds its lane to avoid loop late-binding); each finding reviewed by a different lane.
- **normalize.py** — unknown lane names default to the `sast` category.
- Docs (README, SKILL.md, manifest) rewritten for the lanes schema; `config_schema_version` 1→2; version 0.2.0→0.3.0.

## Verification
- New `lanes:` config and legacy `scanners:` config both load (legacy prints a migration notice).
- A custom lane named `audit` (backend claude-cli) files `audit.*` findings, category `sast`.
- Cross-validate across custom names `audit`↔`check`: each judged "real" by the other.
- `_validate_lanes` rejects bad names, path-y binaries, non-local ollama URLs, and duplicates.

## Pre-commit gate
0 CRITICAL / 0 HIGH. Fixed the two findings tied to new surface: `binary` restricted to a bare command name (no arbitrary path execution), and `lane.name` restricted to `[A-Za-z0-9_-]+` (can't malform SARIF/issue titles). Deferred as pre-existing follow-ups: full `os.environ` inheritance by the CLI runners, load-time `triage.base_url` loopback check, and `redact_text()` on subprocess error strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)